### PR TITLE
Fix/sales tax not selectable

### DIFF
--- a/controllers/phreebooks/functions.php
+++ b/controllers/phreebooks/functions.php
@@ -579,20 +579,10 @@ function getTaxRate($taxID=0)
 function loadTaxes($type, $date=false)
 {
     if (!$date) { $date = biz_date('Y-m-d'); }
-    $output   = [];
-    $taxRates = getModuleCache('phreebooks', 'sales_tax', $type, false, []);
-    if (empty($taxRates)) { // cache not yet populated — build it from common_meta
-        $rows = dbMetaGet('%', "tax_rate_$type");
-        foreach ((array)$rows as $row) {
-            $auths = !empty($row['taxAuths']['rows']) ? $row['taxAuths']['rows'] : [];
-            $taxRates[] = ['id'=>$row['_rID'],'title'=>$row['title'],'rate'=>$row['tax_rate'],'status'=>$row['inactive'],'settings'=>$auths];
-        }
-        if (!empty($taxRates)) { setModuleCache('phreebooks', 'sales_tax', $type, $taxRates); }
-    }
+    $output  = [];
+    $taxRates= getModuleCache('phreebooks', 'sales_tax', $type, false, []);
     foreach ($taxRates as $row) {
-        // 'settings' may be stored as rows array (new) or full datagrid structure (old) — always extract the rows
-        $auths = isset($row['settings']['rows']) ? $row['settings']['rows'] : (array)($row['settings'] ?? []);
-        $output[] = ['id'=>$row['id'],'text'=>$row['title'],'tax_rate'=>$row['rate']." %",'status'=>$row['status'],'auths'=>$auths];
+        $output[] = ['id'=>$row['id'],'text'=>$row['title'],'tax_rate'=>$row['rate']." %",'status'=>$row['status'],'auths'=>$row['settings']];
     }
     array_unshift($output, ['id'=>'0', 'text'=>lang('none'), 'status'=>0, 'tax_rate'=>"0 %", 'auths'=>[]]);
     return $output;

--- a/controllers/phreebooks/functions.php
+++ b/controllers/phreebooks/functions.php
@@ -579,10 +579,20 @@ function getTaxRate($taxID=0)
 function loadTaxes($type, $date=false)
 {
     if (!$date) { $date = biz_date('Y-m-d'); }
-    $output  = [];
-    $taxRates= getModuleCache('phreebooks', 'sales_tax', $type, false, []);
+    $output   = [];
+    $taxRates = getModuleCache('phreebooks', 'sales_tax', $type, false, []);
+    if (empty($taxRates)) { // cache not yet populated — build it from common_meta
+        $rows = dbMetaGet('%', "tax_rate_$type");
+        foreach ((array)$rows as $row) {
+            $auths = !empty($row['taxAuths']['rows']) ? $row['taxAuths']['rows'] : [];
+            $taxRates[] = ['id'=>$row['_rID'],'title'=>$row['title'],'rate'=>$row['tax_rate'],'status'=>$row['inactive'],'settings'=>$auths];
+        }
+        if (!empty($taxRates)) { setModuleCache('phreebooks', 'sales_tax', $type, $taxRates); }
+    }
     foreach ($taxRates as $row) {
-        $output[] = ['id'=>$row['id'],'text'=>$row['title'],'tax_rate'=>$row['rate']." %",'status'=>$row['status'],'auths'=>$row['settings']];
+        // 'settings' may be stored as rows array (new) or full datagrid structure (old) — always extract the rows
+        $auths = isset($row['settings']['rows']) ? $row['settings']['rows'] : (array)($row['settings'] ?? []);
+        $output[] = ['id'=>$row['id'],'text'=>$row['title'],'tax_rate'=>$row['rate']." %",'status'=>$row['status'],'auths'=>$auths];
     }
     array_unshift($output, ['id'=>'0', 'text'=>lang('none'), 'status'=>0, 'tax_rate'=>"0 %", 'auths'=>[]]);
     return $output;

--- a/controllers/phreebooks/tax.php
+++ b/controllers/phreebooks/tax.php
@@ -184,11 +184,30 @@ function preSubmit() {
         $rID = clean('_rID', 'integer', 'post');
         if (!$security = validateAccess($this->secID, empty($rID)?2:3)) { return; }
         parent::saveMeta($layout, $args=['_rID'=>$rID]);
+        $this->rebuildCache();
+        $layout['content']['actionData'] .= " reloadSessionStorage();";
     }
     public function delete(&$layout=[])
     {
         if (!$security = validateAccess($this->secID, 4)) { return; }
         parent::deleteMeta($layout, ['_table'=>'common']);
+        $this->rebuildCache();
+        $layout['content']['actionData'] .= " reloadSessionStorage();";
+    }
+    private function rebuildCache()
+    {
+        $cache = [];
+        $rows  = dbMetaGet('%', $this->metaPrefix);
+        foreach ((array)$rows as $row) {
+            $cache[] = [
+                'id'      => $row['_rID'],
+                'title'   => $row['title'],
+                'rate'    => $row['tax_rate'],
+                'status'  => $row['inactive'],
+                'settings'=> !empty($row['taxAuths']['rows']) ? $row['taxAuths']['rows'] : [],
+            ];
+        }
+        setModuleCache('phreebooks', 'sales_tax', $this->type, $cache);
     }
 
     private function cleanAuths($auths=[])

--- a/controllers/phreebooks/tax.php
+++ b/controllers/phreebooks/tax.php
@@ -184,30 +184,11 @@ function preSubmit() {
         $rID = clean('_rID', 'integer', 'post');
         if (!$security = validateAccess($this->secID, empty($rID)?2:3)) { return; }
         parent::saveMeta($layout, $args=['_rID'=>$rID]);
-        $this->rebuildCache();
-        $layout['content']['actionData'] .= " reloadSessionStorage();";
     }
     public function delete(&$layout=[])
     {
         if (!$security = validateAccess($this->secID, 4)) { return; }
         parent::deleteMeta($layout, ['_table'=>'common']);
-        $this->rebuildCache();
-        $layout['content']['actionData'] .= " reloadSessionStorage();";
-    }
-    private function rebuildCache()
-    {
-        $cache = [];
-        $rows  = dbMetaGet('%', $this->metaPrefix);
-        foreach ((array)$rows as $row) {
-            $cache[] = [
-                'id'      => $row['_rID'],
-                'title'   => $row['title'],
-                'rate'    => $row['tax_rate'],
-                'status'  => $row['inactive'],
-                'settings'=> !empty($row['taxAuths']['rows']) ? $row['taxAuths']['rows'] : [],
-            ];
-        }
-        setModuleCache('phreebooks', 'sales_tax', $this->type, $cache);
     }
 
     private function cleanAuths($auths=[])

--- a/portal/api.php
+++ b/portal/api.php
@@ -216,7 +216,7 @@ class portalApi
         // CSRF Layer 2: rotate the synchronizer token so a token from this session can't
         // be reused after the user signs back in (defense-in-depth against session-fixation).
         if (function_exists("\\bizuno\\bizCsrfRotate")) { bizCsrfRotate(); }
-        $layout = array_replace_recursive($layout, ['type'=>'page', 'jsHead'=>['redir'=>"window.location='".BIZUNO_URL_PORTAL."';"]]);
+        $layout = array_replace_recursive($layout, ['type'=>'page', 'jsHead'=>['redir'=>"sessionStorage.removeItem('bizuno'); window.location='".BIZUNO_URL_PORTAL."';"]]);
         if (function_exists("\\bizuno\\portalLogout")) { portalLogout($layout); }
     }
 

--- a/portal/api.php
+++ b/portal/api.php
@@ -216,7 +216,7 @@ class portalApi
         // CSRF Layer 2: rotate the synchronizer token so a token from this session can't
         // be reused after the user signs back in (defense-in-depth against session-fixation).
         if (function_exists("\\bizuno\\bizCsrfRotate")) { bizCsrfRotate(); }
-        $layout = array_replace_recursive($layout, ['type'=>'page', 'jsHead'=>['redir'=>"sessionStorage.removeItem('bizuno'); window.location='".BIZUNO_URL_PORTAL."';"]]);
+        $layout = array_replace_recursive($layout, ['type'=>'page', 'jsHead'=>['redir'=>"window.location='".BIZUNO_URL_PORTAL."';"]]);
         if (function_exists("\\bizuno\\portalLogout")) { portalLogout($layout); }
     }
 

--- a/view/main.php
+++ b/view/main.php
@@ -1306,15 +1306,7 @@ function viewSalesTaxDropdown($type='c', $opts='')
     if ($opts=='contacts')  { $output[] = ['id'=>'-1', 'text'=>lang('per_contact'),  'status'=>0, 'tax_rate'=>'-']; }
     if ($opts=='inventory') { $output[] = ['id'=>'-1', 'text'=>lang('per_inventory'),'status'=>0, 'tax_rate'=>'-']; }
     $output[] = ['id'=>'0', 'text'=>lang('none'), 'status'=>0, 'tax_rate'=>0];
-    $taxRates = getModuleCache('phreebooks', 'sales_tax', $type, false, []);
-    if (empty($taxRates)) { // cache not yet populated — read from common_meta directly
-        $rows = dbMetaGet('%', "tax_rate_$type");
-        foreach ((array)$rows as $row) {
-            $taxRates[] = ['id'=>$row['_rID'],'title'=>$row['title'],'rate'=>$row['tax_rate'],'status'=>$row['inactive'],'settings'=>!empty($row['taxAuths']['rows'])?$row['taxAuths']['rows']:[]];
-        }
-        if (!empty($taxRates)) { setModuleCache('phreebooks', 'sales_tax', $type, $taxRates); }
-    }
-    foreach ($taxRates as $row) {
+    foreach (getModuleCache('phreebooks', 'sales_tax', $type, false, []) as $row) {
         if ($row['status'] == 0) { $output[] = ['id'=>$row['id'], 'text'=>$row['title'], 'status'=>$row['status'], 'tax_rate'=>$row['rate']]; }
     }
     return $output;

--- a/view/main.php
+++ b/view/main.php
@@ -1306,7 +1306,15 @@ function viewSalesTaxDropdown($type='c', $opts='')
     if ($opts=='contacts')  { $output[] = ['id'=>'-1', 'text'=>lang('per_contact'),  'status'=>0, 'tax_rate'=>'-']; }
     if ($opts=='inventory') { $output[] = ['id'=>'-1', 'text'=>lang('per_inventory'),'status'=>0, 'tax_rate'=>'-']; }
     $output[] = ['id'=>'0', 'text'=>lang('none'), 'status'=>0, 'tax_rate'=>0];
-    foreach (getModuleCache('phreebooks', 'sales_tax', $type, false, []) as $row) {
+    $taxRates = getModuleCache('phreebooks', 'sales_tax', $type, false, []);
+    if (empty($taxRates)) { // cache not yet populated — read from common_meta directly
+        $rows = dbMetaGet('%', "tax_rate_$type");
+        foreach ((array)$rows as $row) {
+            $taxRates[] = ['id'=>$row['_rID'],'title'=>$row['title'],'rate'=>$row['tax_rate'],'status'=>$row['inactive'],'settings'=>!empty($row['taxAuths']['rows'])?$row['taxAuths']['rows']:[]];
+        }
+        if (!empty($taxRates)) { setModuleCache('phreebooks', 'sales_tax', $type, $taxRates); }
+    }
+    foreach ($taxRates as $row) {
         if ($row['status'] == 0) { $output[] = ['id'=>$row['id'], 'text'=>$row['title'], 'status'=>$row['status'], 'tax_rate'=>$row['rate']]; }
     }
     return $output;


### PR DESCRIPTION
Fixes #3

Tax rates existed in common_meta but the phreebooks/sales_tax module cache was never populated, so all dropdowns showed only "None".  Tax calculation always returned 0 because taxAuths was stored as the full EasyUI datagrid structure {rows,total,footer} but the JS/PHP loops expected a plain array.

- tax.php: rebuildCache() on save/delete; trigger reloadSessionStorage() so the browser picks up changes immediately without a logout
- functions.php: loadTaxes() falls back to dbMetaGet when cache is empty; extracts taxAuths['rows'] (plain array) for settings; compat shim handles stale cached data with the old datagrid structure
- view/main.php: viewSalesTaxDropdown() fallback stores settings key with taxAuths['rows'] so the module cache structure is consistent
- portal/api.php: logout clears sessionStorage so next login forces a fresh loadBrowserSession call