### PR TITLE
Fix strict-MySQL (GoDaddy) fatals on dashboard/report pages

### DIFF
--- a/src/controllers/bizuno/install/migrate-7.0.php
+++ b/src/controllers/bizuno/install/migrate-7.0.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-03-16
+ * @version    7.x Last Update: 2026-06-06 (CREATE TABLE *_meta: TEXT meta_value uses DEFAULT NULL — strict MySQL 8 rejects a literal default on TEXT/BLOB with error 1101)
  * @filesource /controllers/bizuno/install/migrate-7.0.php
  */
 
@@ -178,7 +178,7 @@ function migrate_tables_part_2(&$cron=[])
         dbGetResult("CREATE TABLE `".BIZUNO_DB_PREFIX."common_meta` (
   `id` int(11) NOT NULL COMMENT 'tag:ID;order:1',
   `meta_key` varchar(64) NOT NULL DEFAULT '' COMMENT 'tag:MetaKey;order:10',
-  `meta_value` text NULL DEFAULT '' COMMENT 'tag:MetaValue;order:20'
+  `meta_value` text DEFAULT NULL COMMENT 'tag:MetaValue;order:20'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."common_meta` ADD PRIMARY KEY (`id`);");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."common_meta` MODIFY `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'tag:ID;order:10';");
@@ -192,7 +192,7 @@ function migrate_tables_part_2(&$cron=[])
   `id` int(11) NOT NULL COMMENT 'tag:ID;order:1',
   `ref_id` int(11) NOT NULL COMMENT 'type:hidden;tag:ReferenceID;order:10',
   `meta_key` varchar(64) NOT NULL DEFAULT '' COMMENT 'tag:MetaKey;order:20',
-  `meta_value` text NULL DEFAULT '' COMMENT 'tag:MetaValue;order:30'
+  `meta_value` text DEFAULT NULL COMMENT 'tag:MetaValue;order:30'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."contacts_meta` ADD PRIMARY KEY (`id`);");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."contacts_meta` MODIFY `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'tag:ID;order:10';");
@@ -207,7 +207,7 @@ function migrate_tables_part_2(&$cron=[])
   `id` int(11) NOT NULL COMMENT 'tag:ID;order:1',
   `ref_id` int(11) NOT NULL COMMENT 'type:hidden;tag:ReferenceID;order:10',
   `meta_key` varchar(64) NOT NULL DEFAULT '' COMMENT 'tag:MetaKey;order:20',
-  `meta_value` text NULL DEFAULT '' COMMENT 'tag:MetaValue;order:30'
+  `meta_value` text DEFAULT NULL COMMENT 'tag:MetaValue;order:30'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."inventory_meta` ADD PRIMARY KEY (`id`);");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."inventory_meta` MODIFY `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'tag:ID;order:10';");
@@ -222,7 +222,7 @@ function migrate_tables_part_2(&$cron=[])
   `id` int(11) NOT NULL COMMENT 'tag:ID;order:1',
   `ref_id` int(11) NOT NULL COMMENT 'type:hidden;tag:ReferenceID;order:10',
   `meta_key` varchar(64) NOT NULL DEFAULT '' COMMENT 'tag:MetaKey;order:20',
-  `meta_value` text NOT NULL DEFAULT '' COMMENT 'tag:MetaValue;order:30'
+  `meta_value` text DEFAULT NULL COMMENT 'tag:MetaValue;order:30'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."journal_meta` ADD PRIMARY KEY (`id`);");
         dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX."journal_meta` MODIFY `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'tag:ID;order:10';");

--- a/src/controllers/bizuno/install/tables.php
+++ b/src/controllers/bizuno/install/tables.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-01-11
+ * @version    7.x Last Update: 2026-06-06 (common_meta/contacts_meta/inventory_meta: TEXT meta_value uses DEFAULT NULL, not "NULL DEFAULT ''" — strict MySQL 8 rejects a literal default on TEXT/BLOB with error 1101)
  * @filesource /controllers/bizuno/install/tables.php
  */
 namespace bizuno;
@@ -43,7 +43,7 @@ $tables = [
         'fields' => [
             'id'        => ['format'=>'INT(11)',    'attr'=>"NOT NULL AUTO_INCREMENT",'comment'=>'type:hidden;tag:RecordID;order:1'],
             'meta_key'  => ['format'=>'VARCHAR(64)','attr'=>"DEFAULT NULL",           'comment'=>'tag:MetaKey;order:10'],
-            'meta_value'=> ['format'=>'TEXT',       'attr'=>"NULL DEFAULT ''",        'comment'=>'tag:MetaValue;order:20']],
+            'meta_value'=> ['format'=>'TEXT',       'attr'=>"DEFAULT NULL",           'comment'=>'tag:MetaValue;order:20']],
         'keys' => 'PRIMARY KEY (id), INDEX (meta_key)',
         'attr' => 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'],
     'configuration' => ['module' => 'bizuno',
@@ -176,7 +176,7 @@ $tables = [
             'id'        => ['format'=>'INT(11)',    'attr'=>"NOT NULL AUTO_INCREMENT",'comment'=>'type:hidden;tag:RecordID;order:1'],
             'ref_id'    => ['format'=>'INT(11)',    'attr'=>"NOT NULL DEFAULT '0'",   'comment'=>'type:hidden;tag:ReferenceID;order:20'],
             'meta_key'  => ['format'=>'VARCHAR(64)','attr'=>"DEFAULT NULL",           'comment'=>'tag:MetaKey;order:30'],
-            'meta_value'=> ['format'=>'TEXT',       'attr'=>"NULL DEFAULT ''",        'comment'=>'tag:MetaValue;order:40']],
+            'meta_value'=> ['format'=>'TEXT',       'attr'=>"DEFAULT NULL",           'comment'=>'tag:MetaValue;order:40']],
         'keys' => 'PRIMARY KEY (id), INDEX (ref_id), INDEX (meta_key)',
         'attr' => 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'],
     'inventory' => ['module' => 'inventory',
@@ -292,7 +292,7 @@ $tables = [
             'id'        => ['format'=>'INT(11)',    'attr'=>"NOT NULL AUTO_INCREMENT",'comment'=>'type:hidden;tag:RecordID;order:1'],
             'ref_id'    => ['format'=>'INT(11)',    'attr'=>"NOT NULL DEFAULT '0'",   'comment'=>'type:hidden;tag:ReferenceID;order:20'],
             'meta_key'  => ['format'=>'VARCHAR(64)','attr'=>"DEFAULT NULL",           'comment'=>'tag:MetaKey;order:30'],
-            'meta_value'=> ['format'=>'TEXT',       'attr'=>"NULL DEFAULT ''",        'comment'=>'tag:MetaValue;order:40']],
+            'meta_value'=> ['format'=>'TEXT',       'attr'=>"DEFAULT NULL",           'comment'=>'tag:MetaValue;order:40']],
         'keys' => 'PRIMARY KEY (id), INDEX (ref_id), INDEX (meta_key)',
         'attr' => 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'],
     'journal_cogs_owed' => ['module' => 'phreebooks',

--- a/src/controllers/bizuno/install/upgrade.php
+++ b/src/controllers/bizuno/install/upgrade.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-05-15 (added 7.3.9 gate to repair journal_main.period values that drifted off the post_date period for quality tickets)
+ * @version    7.x Last Update: 2026-06-06 (added 7.4.3 gate to MODIFY *_meta.meta_value to TEXT DEFAULT NULL — repairs the illegal "DEFAULT ''" on TEXT columns carried by pre-7.4.3 imports that fatal on strict MySQL 8 with error 1101)
  * @filesource /controllers/bizuno/install/upgrade.php
  */
 
@@ -195,6 +195,31 @@ function bizunoUpgrade()
         // and set period to the matching fiscal period number. dbMetaSet/getValue helpers aren't
         // used here because this is a bulk single-statement repair.
         repairJournalMainPeriod();
+    }
+
+    if (version_compare($dbVer, '7.4.3') < 0) {
+        // Strict-mode MySQL 8 / MariaDB (GoDaddy and most managed hosts) reject a
+        // literal default on a TEXT/BLOB column with "1101 - BLOB, TEXT, GEOMETRY
+        // or JSON column 'meta_value' can't have a default value". Releases through
+        // 7.4.2 defined the *_meta.meta_value columns as "TEXT NULL DEFAULT ''", so
+        // any database created or imported at that level (e.g. a 7.3.8 import) still
+        // carries the illegal default. The moment Bizuno re-syncs the table
+        // structure (repairTables() issues CHANGE `meta_value` `meta_value` TEXT
+        // <attr> from tables.php), that bad attr was replayed and the statement
+        // fatally errored. 7.4.3 corrected the shipped spec to DEFAULT NULL; this
+        // gate realigns already-installed databases so the column matches. MODIFY is
+        // idempotent — safe to apply whether the column is currently NOT NULL,
+        // NULL DEFAULT '', or already DEFAULT NULL. Comments mirror tables.php.
+        $metaCols = [
+            'common_meta'    => 'tag:MetaValue;order:20',
+            'contacts_meta'  => 'tag:MetaValue;order:40',
+            'inventory_meta' => 'tag:MetaValue;order:40',
+            'journal_meta'   => 'tag:MetaValue;order:40'];
+        foreach ($metaCols as $mTbl => $mCmt) {
+            if (dbFieldExists(BIZUNO_DB_PREFIX.$mTbl, 'meta_value')) {
+                dbGetResult("ALTER TABLE `".BIZUNO_DB_PREFIX.$mTbl."` MODIFY `meta_value` TEXT DEFAULT NULL COMMENT '$mCmt'");
+            }
+        }
     }
 
     // At every upgrade, run the comments repair tool to fix changes to the view structure and add any new phreeform categories

--- a/src/model/db.php
+++ b/src/model/db.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-05-19 (constructor: skip connect attempt + error toast when creds match the portalCFG-sample.php placeholders — that's the fresh-install signal, not a credential failure)
+ * @version    7.x Last Update: 2026-06-06 (constructor: strip ONLY_FULL_GROUP_BY from SESSION sql_mode so report queries with GROUP BY + non-aggregated columns run on GoDaddy/managed hosts that ship that mode enabled)
  * @filesource /model/db.php
  */
 
@@ -86,6 +86,19 @@ class db extends \PDO
                 // already handled it).
                 try { $this->exec("SET NAMES 'utf8'"); }
                 catch (\PDOException $e) { msgDebug("\nSET NAMES skipped (non-fatal): ".$e->getMessage()); }
+                // Relax ONLY_FULL_GROUP_BY for this session. Bizuno's report
+                // queries (Income Statement, Financial Summary, AR/AP aging,
+                // etc.) intentionally select non-aggregated columns alongside
+                // GROUP BY — valid under Bizuno's expected MySQL config but
+                // rejected with "1055 ... incompatible with sql_mode=
+                // only_full_group_by" on hosts that ship that mode enabled
+                // (GoDaddy, many managed/shared hosts). REPLACE() strips just
+                // that one flag from the SESSION sql_mode, leaving every other
+                // protection intact and requiring no special privilege. Wrapped
+                // in try/catch so a host that blocks even this degrades to the
+                // original behavior rather than failing the connection.
+                try { $this->exec("SET SESSION sql_mode=(SELECT REPLACE(@@SESSION.sql_mode,'ONLY_FULL_GROUP_BY',''))"); }
+                catch (\PDOException $e) { msgDebug("\nsql_mode adjust skipped (non-fatal): ".$e->getMessage()); }
                 break;
         }
         $this->connected = true;


### PR DESCRIPTION
Three layered fixes for hosts that run MySQL 8 / MariaDB with strict sql_mode (GoDaddy, most managed/shared hosts):

- db.php: strip ONLY_FULL_GROUP_BY from the session sql_mode after connecting, so report queries that select non-aggregated columns alongside GROUP BY (Income Statement, Financial Summary, AR/AP aging) stop failing with error 1055. Privilege-free, wrapped in try/catch.

- tables.php + migrate-7.0.php: TEXT meta_value columns (common_meta/contacts_meta/inventory_meta/journal_meta) now use DEFAULT NULL instead of "NULL DEFAULT ''". Strict MySQL rejects a literal default on TEXT/BLOB with error 1101, which repairTables() replayed verbatim from the schema spec on every structure re-sync.

- upgrade.php: new 7.4.3 version gate that MODIFYs the existing *_meta.meta_value columns to TEXT DEFAULT NULL, repairing databases imported/created before the schema fix (e.g. a 7.3.8 import) that still carry the illegal default. Idempotent and dbFieldExists-guarded.