### PR TITLE
Fix sales/purchase tax rates not selectable in dropdowns

### DIFF
--- a/src/controllers/phreebooks/functions.php
+++ b/src/controllers/phreebooks/functions.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-05-15 (setNewFiscalYear: replaced misleading postfix-decrement return with explicit "return next_period - 1")
+ * @version    7.x Last Update: 2026-06-07 (loadTaxes: source rates via getSalesTaxRates() with lazy cache rebuild; extract auths rows for both new and stale-datagrid cache shapes)
  * @filesource /controllers/phreebooks/functions.php
  */
 
@@ -580,9 +580,13 @@ function loadTaxes($type, $date=false)
 {
     if (!$date) { $date = biz_date('Y-m-d'); }
     $output  = [];
-    $taxRates= getModuleCache('phreebooks', 'sales_tax', $type, false, []);
-    foreach ($taxRates as $row) {
-        $output[] = ['id'=>$row['id'],'text'=>$row['title'],'tax_rate'=>$row['rate']." %",'status'=>$row['status'],'auths'=>$row['settings']];
+    // getSalesTaxRates() (view/main.php, always loaded) returns the cache, rebuilding it from
+    // common_meta when empty so rates show up without a logout on fresh/imported installs.
+    foreach (getSalesTaxRates($type) as $row) {
+        // 'settings' is normally the plain auths rows array, but a stale cache from an older
+        // release may still hold the full datagrid {rows,total,footer} — extract rows either way.
+        $auths = isset($row['settings']['rows']) ? $row['settings']['rows'] : (array)($row['settings'] ?? []);
+        $output[] = ['id'=>$row['id'],'text'=>$row['title'],'tax_rate'=>$row['rate']." %",'status'=>$row['status'],'auths'=>$auths];
     }
     array_unshift($output, ['id'=>'0', 'text'=>lang('none'), 'status'=>0, 'tax_rate'=>"0 %", 'auths'=>[]]);
     return $output;

--- a/src/controllers/phreebooks/tax.php
+++ b/src/controllers/phreebooks/tax.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-02-28
+ * @version    7.x Last Update: 2026-06-07 (save/delete: rebuild the sales_tax module cache from common_meta and trigger reloadSessionStorage() so tax rates become selectable without a logout)
  * @filesource /controllers/phreebooks/tax.php
  */
 
@@ -184,11 +184,25 @@ function preSubmit() {
         $rID = clean('_rID', 'integer', 'post');
         if (!$security = validateAccess($this->secID, empty($rID)?2:3)) { return; }
         parent::saveMeta($layout, $args=['_rID'=>$rID]);
+        $this->rebuildCache();
+        $layout['content']['actionData'] .= " reloadSessionStorage();";
     }
     public function delete(&$layout=[])
     {
         if (!$security = validateAccess($this->secID, 4)) { return; }
         parent::deleteMeta($layout, ['_table'=>'common']);
+        $this->rebuildCache();
+        $layout['content']['actionData'] .= " reloadSessionStorage();";
+    }
+
+    /**
+     * Regenerates the phreebooks.sales_tax module cache from common_meta after a rate is
+     * saved or deleted, so dropdowns reflect the change immediately (paired with the
+     * reloadSessionStorage() client call that refreshes the browser's cached copy).
+     */
+    private function rebuildCache()
+    {
+        getSalesTaxRates($this->type, true); // force a rebuild from common_meta (view/main.php helper)
     }
 
     private function cleanAuths($auths=[])

--- a/src/portal/api.php
+++ b/src/portal/api.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-05-19 (easyuiJS / easyuiCSS: scripts/ lives at the webroot, not under src/, so resolve via BIZUNO_FS_PORTAL not BIZUNO_FS_LIBRARY)
+ * @version    7.x Last Update: 2026-06-07 (logout: clear sessionStorage('bizuno') on redirect so the next login reloads a fresh browser session cache)
  * @filesource /portal/api.php
  */
 
@@ -243,7 +243,9 @@ class portalApi
         // CSRF Layer 2: rotate the synchronizer token so a token from this session can't
         // be reused after the user signs back in (defense-in-depth against session-fixation).
         if (function_exists("\\bizuno\\bizCsrfRotate")) { bizCsrfRotate(); }
-        $layout = array_replace_recursive($layout, ['type'=>'page', 'jsHead'=>['redir'=>"window.location='".BIZUNO_URL_PORTAL."';"]]);
+        // Clear the cached browser session so the next login forces a fresh loadBrowserSession
+        // (otherwise stale bizDefaults — e.g. an empty taxRates set — survive across re-login).
+        $layout = array_replace_recursive($layout, ['type'=>'page', 'jsHead'=>['redir'=>"sessionStorage.removeItem('bizuno'); window.location='".BIZUNO_URL_PORTAL."';"]]);
         if (function_exists("\\bizuno\\portalLogout")) { portalLogout($layout); }
     }
 

--- a/src/view/main.php
+++ b/src/view/main.php
@@ -21,7 +21,7 @@
  * @author     Dave Premo, PhreeSoft <support@phreesoft.com>
  * @copyright  2008-2026, PhreeSoft, Inc.
  * @license    https://www.gnu.org/licenses/agpl-3.0.txt
- * @version    7.x Last Update: 2026-05-15 (fa_type processor migrated off getModuleCache → getMetaCommon('options_fxdast_types') + lang() translation)
+ * @version    7.x Last Update: 2026-06-07 (viewSalesTaxDropdown: use new getSalesTaxRates() helper that lazily rebuilds the empty sales_tax cache from common_meta so tax rates are selectable on fresh/imported installs)
  * @filesource /view/main.php
  */
 
@@ -1324,10 +1324,44 @@ function viewSalesTaxDropdown($type='c', $opts='')
     if ($opts=='contacts')  { $output[] = ['id'=>'-1', 'text'=>lang('per_contact'),  'status'=>0, 'tax_rate'=>'-']; }
     if ($opts=='inventory') { $output[] = ['id'=>'-1', 'text'=>lang('per_inventory'),'status'=>0, 'tax_rate'=>'-']; }
     $output[] = ['id'=>'0', 'text'=>lang('none'), 'status'=>0, 'tax_rate'=>0];
-    foreach (getModuleCache('phreebooks', 'sales_tax', $type, false, []) as $row) {
+    foreach (getSalesTaxRates($type) as $row) {
         if ($row['status'] == 0) { $output[] = ['id'=>$row['id'], 'text'=>$row['title'], 'status'=>$row['status'], 'tax_rate'=>$row['rate']]; }
     }
     return $output;
+}
+
+/**
+ * Returns the phreebooks.sales_tax module cache rows for a tax type, lazily rebuilding the
+ * cache from common_meta when it is empty (fresh install, or a session opened before the
+ * first tax-rate was saved). Centralizing the rebuild here keeps loadTaxes(),
+ * viewSalesTaxDropdown() and phreebooksTax::rebuildCache() from drifting apart.
+ *
+ * Each row is normalized to the cache shape id|title|rate|status|settings, where `settings`
+ * is the plain auths rows array. `taxAuths` is persisted as the EasyUI datagrid structure
+ * {rows,total,footer}; only `rows` is meaningful downstream, so it is extracted here.
+ *
+ * This helper lives in view/main.php because that file is require_once'd globally in
+ * bizunoCFG.php, so every caller (including view-layer callers that never load
+ * phreebooks/functions.php) can reach it.
+ * @param char $type - 'c' (customers) or 'v' (vendors)
+ * @param boolean $force - true to bypass the cache and rebuild from common_meta (used after save/delete)
+ * @return array - list of tax-rate rows (may be empty)
+ */
+function getSalesTaxRates($type, $force=false)
+{
+    if (!$force) {
+        $taxRates = getModuleCache('phreebooks', 'sales_tax', $type, false, []);
+        if (!empty($taxRates)) { return $taxRates; }
+    }
+    $taxRates = [];
+    foreach ((array)dbMetaGet('%', "tax_rate_$type") as $row) {
+        $taxRates[] = ['id'=>$row['_rID'], 'title'=>$row['title'], 'rate'=>$row['tax_rate'], 'status'=>$row['inactive'],
+            'settings'=>!empty($row['taxAuths']['rows']) ? $row['taxAuths']['rows'] : []];
+    }
+    // On a forced rebuild always write (so deleting the last rate clears the cache too); on the
+    // lazy path only cache a non-empty result to avoid pinning an empty array on fresh installs.
+    if ($force || !empty($taxRates)) { setModuleCache('phreebooks', 'sales_tax', $type, $taxRates); }
+    return $taxRates;
 }
 
 /**


### PR DESCRIPTION
Addresses #3. Re-applies and supersedes #4 (by @billj9000), rebased onto the current `src/` layout, squashed, and de-duplicated.

## Problem
Sales-tax dropdowns in Sales/Purchase only ever showed "None" and tax always calculated as 0:
1. The `phreebooks.sales_tax` module cache is never populated — saving a tax rate writes to `common_meta` but nothing rebuilds the cache the dropdowns read.
2. `taxAuths` is persisted as the EasyUI datagrid structure `{rows,total,footer}`, but the PHP/JS loops expected a plain auths array.

## Fix
- **`view/main.php`** — new `getSalesTaxRates($type, $force)` helper that lazily rebuilds the cache from `common_meta` when empty and normalizes each row (extracting `taxAuths['rows']`). `viewSalesTaxDropdown()` uses it. Placed here because `view/main.php` is `require_once`'d globally, whereas `phreebooks/functions.php` is only autoloaded for phreebooks controllers — view/inventory callers of `viewSalesTaxDropdown` would otherwise risk an undefined-function fatal.
- **`controllers/phreebooks/functions.php`** — `loadTaxes()` sources rates via the helper; auths extraction handles both the new rows-array and stale-datagrid cache shapes.
- **`controllers/phreebooks/tax.php`** — `save()`/`delete()` rebuild the cache from `common_meta` and trigger `reloadSessionStorage()` so rates are selectable immediately without a logout.
- **`portal/api.php`** — logout clears `sessionStorage('bizuno')` so the next login reloads a fresh browser session cache.

## Notes vs #4
- Rebased onto current `main` (#4 targeted the pre-`src/` layout and no longer merges).
- Squashed the commit → revert → re-apply churn into one commit.
- De-duplicated the cache-fallback logic (was copy-pasted into `loadTaxes` and `viewSalesTaxDropdown`) into the single `getSalesTaxRates()` helper.
- Bumped `@version` headers on all four files.

Original work and credit: @billj9000 (#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)