### PR TITLE
docs(inventory): Inventory module section

### DIFF
--- a/docs/04-modules-in-depth/03-inventory/01-inventory-types.md
+++ b/docs/04-modules-in-depth/03-inventory/01-inventory-types.md
@@ -2,30 +2,126 @@
 title: Inventory Types
 category: Inventory
 order: 1
-status: stub
+status: draft
 audience: [bookkeeper, admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Inventory Types
 
-> **Status:** Stub — not yet drafted.
+Every inventory item carries a two-letter **type code** that decides almost
+everything about how it behaves: whether it tracks stock quantity, whether it
+posts Cost of Goods Sold, whether it can have a bill of materials, and where its
+cost comes from. This page is the full per-code reference.
 
-## What this page will cover
+> **The type is effectively permanent.** Once an item has posted transactions,
+> Bizuno locks its type (and its SKU and cost method) — the field becomes
+> read-only. Changing type after you've transacted means rebuilding the item's
+> history, not editing a dropdown. Pick deliberately. See
+> [Why the type is permanent](#why-the-type-is-permanent).
 
-- Full per-type reference: physical stock, service, kit, raw material, finished good, charge-only, etc.
-- Which types are in `INVENTORY_COGS_TYPES` and therefore post to COGS
-- Behavior at receive, sale, return, adjustment per type
-- Type-specific fields (e.g. assembly components on `ma`/`mi`)
-- Picking the right type — decision flowchart
-- Why changing type after transactions is a re-build, not an edit
+---
 
-## Why it matters
+## The two big questions
 
-Builds on [Inventory types and COGS](../../02-core-concepts/05-inventory-types-and-cogs.md)
-with the full per-letter reference.
+Two flags, derived from the type, drive the accounting:
+
+- **Does it track stock?** Tracked types maintain a real `qty_stock` (and
+  on-order `qty_po` / `qty_so`). Non-tracked types are set to a nominal quantity
+  of 1 and never decrement.
+- **Does it post COGS?** The constant `INVENTORY_COGS_TYPES` =
+  `['ma','mi','ms','sa','si','sr']` lists the types that carry inventory cost and
+  post to a COGS account when sold. Everything else expenses immediately or
+  carries no cost at all.
+
+Get those two right for what you sell and the rest follows.
+
+---
+
+## The full type reference
+
+| Code | Name                   | Tracks stock | Posts COGS | BOM | Notes                                             |
+|------|------------------------|:------------:|:----------:|:---:|---------------------------------------------------|
+| `si` | Stock Item             | ✓            | ✓          | —   | The default. A physical good you buy and sell.    |
+| `sr` | Serialized Stock       | ✓            | ✓          | —   | Like `si`, but each unit carries a serial number. |
+| `ma` | Assembly               | ✓            | ✓          | ✓   | Built from component SKUs via a bill of materials. |
+| `sa` | Serialized Assembly    | ✓            | ✓          | ✓   | An assembly whose finished units are serialized.  |
+| `ms` | Master Stock           | ✓            | ✓          | —   | A template that generates variant items (`mi`) from options (size/color/…). |
+| `mi` | Master Stock Sub-Item  | ✓            | (see note) | —   | Auto-generated variant of an `ms` master. Hidden type — you don't create these by hand. |
+| `ns` | Non-stock              | —            | —          | —   | Bought/sold but not inventoried (drop-ship, one-offs). |
+| `lb` | Labor                  | —            | —          | —   | Labor / hours.                                    |
+| `sv` | Service                | —            | —          | —   | A service you sell.                               |
+| `sf` | Flat-Rate Service      | —            | —          | —   | A fixed-price service charge.                     |
+| `ci` | Charge                 | —            | —          | —   | A miscellaneous charge line.                      |
+| `ai` | Activity               | —            | —          | —   | An activity/time line.                            |
+| `ds` | Description            | —            | —          | —   | A text-only line — no price, no cost.             |
+| `ia` | Assembly Part          | ✓            | —          | —   | Internal/hidden — used behind the scenes for assembly components. |
+
+> **About `mi` and `ia`.** They relate to the COGS-types machinery because they
+> track stock cost, but they're flagged `gl_cogs = false` — they don't post their
+> own COGS legs and aren't types you choose from the dropdown. `mi` is spawned by
+> a Master Stock item; `ia` is internal. You'll work with the other twelve.
+
+---
+
+## Tracked vs. non-tracked, in practice
+
+**Tracked** types (`si`, `sr`, `ma`, `sa`, `ms`, `mi`) are the inventory you count.
+They decrement on sale, increment on receipt, carry a cost layer in
+`inventory_history`, and post COGS at sale time. Their value sits on the balance
+sheet as an asset until sold. See [History and costing](./02-history-and-costing.md).
+
+**Non-tracked** types (`ns`, `lb`, `sv`, `sf`, `ci`, `ai`, `ds`) don't hold a real
+quantity — Bizuno parks `qty_stock` at 1 so they behave on documents but never
+deplete. They have no COGS leg; the expense (if any) is recognized when you buy
+the underlying thing, not when you sell the line. Use them for services, labor,
+freight/charge lines, and pure description rows.
+
+---
+
+## Type-specific behavior
+
+### Assemblies (`ma`, `sa`)
+
+Only `ma` and `sa` can carry a **bill of materials** — the component list that
+defines what the finished item is built from. The BOM lives in item metadata and
+drives both build cost and "how many can I build" availability. Full detail in
+[Assemblies](./03-assemblies.md).
+
+### Master Stock (`ms` → `mi`)
+
+A Master Stock item is **not** an assembly — it's a template. You define *options*
+(size, color, etc.) and Bizuno generates a child **`mi`** variant per
+combination, each with its own SKU and stock. You manage the master; the variants
+are produced from it and are hidden as a standalone type.
+
+---
+
+## Why the type is permanent
+
+Two safeguards enforce this:
+
+1. **Edit lock.** When an item has any journal history, the entry form marks
+   `inventory_type`, `sku`, and `cost_method` **read-only**. Because read-only
+   fields aren't submitted, they can't be changed even by tampering with the form.
+2. **Delete block.** You can't delete an item that has GL journal entries if it's
+   a COGS-tracking type — its history would be orphaned.
+
+The reason is integrity: the type determines whether each past transaction posted
+COGS and tracked stock. Retyping retroactively would make historical postings
+inconsistent with the item's nature. If you truly need a different type, create a
+**new SKU** with the correct type and retire the old one (mark it inactive).
+
+> **Decision shortcut.** Physical thing you stock and resell → `si` (or `sr` if
+> serialized). Built from parts → `ma`/`sa`. Sized/colored variants → `ms`.
+> Service, labor, or freight → `sv`/`lb`/`ci`. Bought-to-order, never stocked →
+> `ns`. Pure text on a form → `ds`.
+
+---
 
 ## Related
 
-- [Inventory types and COGS](../../02-core-concepts/05-inventory-types-and-cogs.md)
-- [History and costing](./02-history-and-costing.md)
+- [History and costing](./02-history-and-costing.md) — how tracked types are costed
+- [Assemblies](./03-assemblies.md) — `ma`/`sa` bills of materials
+- [Inventory types and COGS](../../02-core-concepts/05-inventory-types-and-cogs.md) — the concept
+- [Journals (the journal_id reference)](../01-phreebooks/02-journals.md) — what posts the COGS legs

--- a/docs/04-modules-in-depth/03-inventory/01-inventory-types.md
+++ b/docs/04-modules-in-depth/03-inventory/01-inventory-types.md
@@ -2,7 +2,7 @@
 title: Inventory Types
 category: Inventory
 order: 1
-status: draft
+status: published
 audience: [bookkeeper, admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/03-inventory/02-history-and-costing.md
+++ b/docs/04-modules-in-depth/03-inventory/02-history-and-costing.md
@@ -2,31 +2,165 @@
 title: History and Costing
 category: Inventory
 order: 2
-status: stub
+status: draft
 audience: [bookkeeper, admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # History and Costing
 
-> **Status:** Stub — not yet drafted.
+"What did this widget actually cost me?" is the question behind every margin on
+every report. Bizuno answers it with a per-SKU cost ledger (`inventory_history`)
+and a per-item costing method. Misunderstand the method and you misreport COGS on
+every sale — so this page is worth reading before you go live.
 
-## What this page will cover
+---
 
-- `inventory_history` table — the per-SKU running ledger Bizuno consults for COGS calculation
-- FIFO vs. average vs. standard cost — which one Bizuno uses, how to configure
-- How costing happens on receive (PO price, landed cost adjustments)
-- COGS calculation at time of sale
-- Adjustment transactions (write-down, write-up, count adjustment)
-- Recomputing history after data corruption (when, how, the rebuild tool)
+## The cost ledger: `inventory_history`
 
-## Why it matters
+Every time stock comes **in** (a purchase receipt, a positive adjustment, an
+assembly build), Bizuno writes a **cost layer** to `inventory_history`. Each layer
+records:
 
-The "what did this widget cost me" question is core to running a profitable
-shop. Misunderstanding the costing method leads to wrong margins on every
-report.
+| Field        | Meaning                                                      |
+|--------------|--------------------------------------------------------------|
+| `sku`        | The item                                                     |
+| `qty`        | Quantity received in this layer                              |
+| `remaining`  | How much of this layer is still unsold (decrements over time)|
+| `unit_cost`  | The cost per unit at receipt                                 |
+| `avg_cost`   | The weighted-average cost as of this layer                   |
+| `post_date`  | When it posted                                               |
+| `ref_id` / `journal_id` | The transaction (and journal) that created it    |
+| `trans_code` | Serial number, for serialized items                         |
+| `store_id`   | The store, for multi-store                                   |
+
+When stock goes **out** (a sale, a negative adjustment, component consumption in a
+build), Bizuno *consumes* from these layers — drawing down `remaining` — and the
+cost it pulls is your COGS. How it picks which layer to draw from is the costing
+method.
+
+---
+
+## Costing methods
+
+The method is a **per-item** setting (`cost_method` on the inventory record):
+
+| `cost_method` | Method   | How COGS is drawn                                  |
+|:-------------:|----------|----------------------------------------------------|
+| `f`           | **FIFO** (default) | Oldest layer first (`post_date` ascending) |
+| `l`           | **LIFO** | Newest layer first (`post_date` descending)        |
+| `a`           | **Average** | Weighted average across available layers        |
+
+### Setting the method
+
+- **Per item:** each SKU stores its own `cost_method`. It's chosen at creation and
+  **locks** once the item has transactions (read-only thereafter — see
+  [Inventory types](./01-inventory-types.md#why-the-type-is-permanent)).
+- **Per-type default:** new items inherit the default for their type from
+  *Settings → Inventory* (`method_si`, `method_ma`, `method_ms`, `method_sr`,
+  `method_sa`). Set these to your shop's convention so new SKUs come out right.
+
+> **Be consistent.** Mixing methods across similar items makes margin reports hard
+> to reason about. Most shops pick one (commonly FIFO) and standardize the
+> per-type defaults to match.
+
+---
+
+## Cost on receive
+
+When a purchase/bill (jID 6) posts with a positive quantity, Bizuno writes a new
+`inventory_history` layer at the line's cost and, for average-cost items,
+recomputes `avg_cost`:
+
+```
+avg_cost = (prior_avg × stock_on_hand + receipt_price × receipt_qty)
+           ────────────────────────────────────────────────────────
+                       (stock_on_hand + receipt_qty)
+```
+
+### Auto-cost from the document
+
+The `auto_cost` setting (*Settings → Inventory*) can keep the item's standing cost
+in step with what you actually pay:
+
+| `auto_cost` | Behavior                                                   |
+|:-----------:|------------------------------------------------------------|
+| `0`         | Off — item cost is whatever you set manually               |
+| `PO`        | Update item cost from the **Purchase Order** price (jID 4) |
+| `PR`        | Update item cost from the **Purchase Receipt** price (jID 6) — `item_cost = line debit ÷ qty` |
+
+There's no separate landed-cost field — whatever you put in the line cost is the
+cost that's captured. To include freight/duty in unit cost, fold it into the line.
+
+---
+
+## COGS on sale
+
+When a sale (jID 12) posts, Bizuno generates the COGS legs (`gl_type='cog'`)
+automatically — you never type them. The cost comes from the layers:
+
+- **FIFO / LIFO:** walk `inventory_history` layers in date order, consuming
+  `remaining` from each until the sold quantity is covered. Each draw is recorded
+  in **`journal_cogs_usage`** (which layer, how much) so the consumption is
+  auditable and reversible.
+- **Average:** use the weighted `avg_cost` as of the sale date.
+
+### Selling stock you don't have yet
+
+If a sale would drive stock negative:
+
+- **FIFO/LIFO** allow it (when negative stock is permitted): Bizuno estimates COGS
+  from the item's standing cost and queues the shortfall in **`journal_cogs_owed`**.
+  When stock later arrives at a real cost, the affected sales **re-post** to
+  correct their COGS. (This is part of the broader
+  [re-post chain](../01-phreebooks/02-journals.md#the-re-post-chain).)
+- **Average** does **not** allow negative stock — the post is rejected, because
+  there's no meaningful average to draw from.
+
+> Because an average-cost **receipt** changes the running average, posting one
+> triggers a re-post of later sales of that SKU so their COGS reflects the updated
+> average. Expect a small edit to ripple forward — by design.
+
+---
+
+## Adjustments (jID 16)
+
+Inventory adjustments — cycle counts, shrinkage, write-ups/downs — post with
+`gl_type='adj'`:
+
+- A **positive** adjustment behaves like a receipt: it adds a cost layer and
+  raises `qty_stock`.
+- A **negative** adjustment behaves like a sale: it consumes layers and lowers
+  `qty_stock`.
+
+Use them to bring book quantity back in line with a physical count, or to
+write inventory value up or down.
+
+---
+
+## When history drifts: repair tools
+
+Stock quantity and the sum of layer `remaining` should always agree. If they
+drift (interrupted posts, old data, a bad import), two tools under *Admin →
+Inventory → Tools* fix it:
+
+- **Repair Inventory History** (`historyTestRepair()`) — validates that each SKU's
+  `qty_stock` equals the sum of its `inventory_history.remaining` (less anything
+  owed), and corrects rounding/zero-out errors. Run in **test** mode first to see
+  what it would change.
+- **Recalculate History** (`recalcHistory()`) — the heavier rebuild: re-derives
+  history from the journal entries for corruption recovery, batching through SKUs
+  and logging mismatches to a CSV for review.
+
+> Run the test/repair pass before trusting margin reports after any bulk import or
+> a restore. The recalc is the bigger hammer — reach for it only when repair isn't
+> enough.
+
+---
 
 ## Related
 
-- [Inventory types](./01-inventory-types.md)
+- [Inventory types](./01-inventory-types.md) — which types are costed
+- [Assemblies](./03-assemblies.md) — how a built item's cost is rolled up
+- [Journals (the journal_id reference)](../01-phreebooks/02-journals.md) — the COGS legs and re-post chain
 - [Inventory types and COGS](../../02-core-concepts/05-inventory-types-and-cogs.md)

--- a/docs/04-modules-in-depth/03-inventory/02-history-and-costing.md
+++ b/docs/04-modules-in-depth/03-inventory/02-history-and-costing.md
@@ -2,7 +2,7 @@
 title: History and Costing
 category: Inventory
 order: 2
-status: draft
+status: published
 audience: [bookkeeper, admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/03-inventory/03-assemblies.md
+++ b/docs/04-modules-in-depth/03-inventory/03-assemblies.md
@@ -16,10 +16,10 @@ into the assembled SKU. This page covers the data model and the costing; the
 build workflow itself is in [Work orders / production](./04-work-orders-production.md).
 
 > **Scope check.** Bizuno's assembly model is solid for kitting and light
-> manufacturing, but it is **not** a full MRP. In particular: **labor and overhead
-> are not captured** — an assembly's cost is the sum of its components, nothing
-> more. If you need labor/burden in standard cost, you'll add it through the GL by
-> other means. See [Honest limits](#honest-limits).
+> manufacturing, but it is **not** a full MRP — no work centers, routings, or
+> capacity planning. You *can*, however, build **labor and overhead into the
+> assembly cost** by adding labor- or charge-type lines to the bill of materials
+> (see [Costing labor and overhead](#costing-labor-and-overhead)).
 
 ---
 
@@ -68,6 +68,32 @@ parent — otherwise the parent rolls up a stale sub-assembly cost.
 
 ---
 
+## Costing labor and overhead
+
+Labor and overhead don't need a separate cost field — model them as **inventory
+items** and drop them into the bill of materials like any other line:
+
+1. Create a labor- or charge-type item — e.g. a Labor (`lb`) item *"Assembly
+   labor"* with an `item_cost` of `$3.00` representing 0.1 hours of work (or
+   however you prefer to unitize it). Do the same for overhead/burden if you
+   track it.
+2. Add that item to the assembly's BOM with the **quantity** you need — e.g. 5 ×
+   *"Assembly labor"* for 0.5 hours of build time.
+
+Bizuno includes these lines when it rolls up the assembly's cost
+(`dbGetInvAssyCost` sums `qty × item_cost` across **every** BOM line, regardless of
+type), so the finished item's standing cost reflects materials **plus** the labor
+and overhead you've itemized.
+
+> **One nuance to know.** Labor/charge items are non-stock, so at *build-post*
+> time (jID 14) they aren't moved through inventory/COGS accounts the way stocked
+> components are — they contribute to the item's **computed cost**, not to a
+> separate GL inventory leg. For most shops the computed cost is exactly what you
+> want on margin reports; just be aware the labor isn't capitalized as its own
+> ledger entry during the build.
+
+---
+
 ## Building: what posts
 
 A build is recorded by the **Assembly journal (jID 14)**. Its `Post()`:
@@ -98,20 +124,22 @@ What the assembly model **does**:
 
 - Component bills of materials on `ma`/`sa` items
 - Build / un-build with correct stock movement and component-cost rollup
+- **Labor and overhead** in cost, via labor/charge items on the BOM (above)
 - Multi-level **availability** (recursive "can I build N?")
 - "How many can I build per store" capability view
 
 What it **does not** do (so you don't design around features that aren't there):
 
-- **No labor or overhead** in assembly cost — components only.
+- **No work centers, routings, or capacity planning** — the build is a recipe,
+  not a routed operation.
 - **No recursive cost rollup** — parent cost reflects direct components only;
-  build sub-assemblies first.
+  build sub-assemblies first so their cost is current.
 - **No phantom assemblies** — there's no "don't stock the assembly level" flag;
   every build moves real stock for both components and the finished item.
 
-For kitting and straightforward builds this is plenty. For routings, work centers,
-labor capture, and burden, you've crossed into territory a dedicated MRP handles
-better.
+For kitting and light builds — including itemized labor and overhead — this is
+plenty. For routed operations through work centers with capacity scheduling,
+you've crossed into territory a dedicated MRP handles better.
 
 ---
 

--- a/docs/04-modules-in-depth/03-inventory/03-assemblies.md
+++ b/docs/04-modules-in-depth/03-inventory/03-assemblies.md
@@ -2,31 +2,122 @@
 title: Assemblies
 category: Inventory
 order: 3
-status: stub
+status: draft
 audience: [bookkeeper, admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Assemblies
 
-> **Status:** Stub — not yet drafted.
+An **assembly** is an inventory item built from other items. You define what it's
+made of (the bill of materials), and when you build it Bizuno consumes the
+components and produces the finished good — moving cost from the component SKUs
+into the assembled SKU. This page covers the data model and the costing; the
+build workflow itself is in [Work orders / production](./04-work-orders-production.md).
 
-## What this page will cover
+> **Scope check.** Bizuno's assembly model is solid for kitting and light
+> manufacturing, but it is **not** a full MRP. In particular: **labor and overhead
+> are not captured** — an assembly's cost is the sum of its components, nothing
+> more. If you need labor/burden in standard cost, you'll add it through the GL by
+> other means. See [Honest limits](#honest-limits).
 
-- Assembly SKUs (`ma`, `mi`) — composed of component SKUs
-- Defining the bill of materials (BOM)
-- Build-to-order vs. build-to-stock — when each makes sense
-- The build transaction (jID=32 work order) — pulls components, produces assembly, captures labor
-- COGS rollup: cost of the assembly = sum of components + labor + overhead
-- Phantom assemblies (kits that don't track stock at the assembly level)
-- Multi-level BOMs (assembly contains an assembly)
+---
 
-## Why it matters
+## Which types are assemblies
 
-Assemblies are where manufacturing-flavor users separate from straight
-retail. The data model is more nuanced than a single-SKU inventory.
+Only two types carry a bill of materials:
+
+- **`ma` — Assembly**: the normal built item.
+- **`sa` — Serialized Assembly**: the same, with serial numbers on finished units.
+
+(Don't confuse these with **`ms` Master Stock**, which generates *variants* from
+options and is not an assembly — see [Inventory types](./01-inventory-types.md).)
+
+---
+
+## The bill of materials
+
+The BOM is stored as item metadata (`bill_of_materials`) on the assembly SKU — a
+list of component rows, each with:
+
+| Field         | Meaning                          |
+|---------------|----------------------------------|
+| `sku`         | The component item               |
+| `description` | Component description            |
+| `qty`         | How many per one assembled unit  |
+
+Edit it on the assembly item's **Assembly** tab (visible only for `ma`/`sa`). As
+you build the list, Bizuno shows the rolled-up component quantity and cost in the
+footer (`managerBOMList`).
+
+> **The BOM locks once you transact.** After the assembly SKU has any posted
+> journal activity, its bill of materials is locked from editing — changing it
+> would make past builds inconsistent with the recipe. To change a recipe in
+> flight, version it as a new SKU.
+
+### Multi-level BOMs
+
+A component can itself be an assembly, and Bizuno **does** handle that for
+**availability** — the "how many can I build" calculation recurses through
+sub-assemblies to find the limiting component.
+
+**Cost rollup, however, does not recurse.** An assembly's build cost is computed
+from the **direct** components' costs (one level). If you nest assemblies, build
+the sub-assemblies first so their finished cost is current before you build the
+parent — otherwise the parent rolls up a stale sub-assembly cost.
+
+---
+
+## Building: what posts
+
+A build is recorded by the **Assembly journal (jID 14)**. Its `Post()`:
+
+1. Reads the BOM, and for each component creates a consumption leg
+   (`gl_type='asi'`) — drawing the component's cost via its
+   [costing method](./02-history-and-costing.md) (FIFO/LIFO/average) and
+   **decrementing** its `qty_stock`.
+2. Creates the assembled-item leg (`gl_type='asy'`) — **incrementing** the
+   assembly's `qty_stock` and adding a cost layer.
+3. Rolls the cost: **assembled cost = sum of the components' COGS**, and the
+   finished unit cost = that total ÷ quantity built.
+4. Marks the build closed.
+
+The GL effect nets within your inventory/COGS accounts — value simply moves from
+the component SKUs to the finished SKU. Reversing a build (un-post) puts the
+components back and removes the finished units.
+
+> You don't usually post a jID 14 by hand — it's created for you when a
+> [work order](./04-work-orders-production.md) step completes. The jID 14 is the
+> accounting record; the work order is the shop-floor workflow that drives it.
+
+---
+
+## Honest limits
+
+What the assembly model **does**:
+
+- Component bills of materials on `ma`/`sa` items
+- Build / un-build with correct stock movement and component-cost rollup
+- Multi-level **availability** (recursive "can I build N?")
+- "How many can I build per store" capability view
+
+What it **does not** do (so you don't design around features that aren't there):
+
+- **No labor or overhead** in assembly cost — components only.
+- **No recursive cost rollup** — parent cost reflects direct components only;
+  build sub-assemblies first.
+- **No phantom assemblies** — there's no "don't stock the assembly level" flag;
+  every build moves real stock for both components and the finished item.
+
+For kitting and straightforward builds this is plenty. For routings, work centers,
+labor capture, and burden, you've crossed into territory a dedicated MRP handles
+better.
+
+---
 
 ## Related
 
-- [Work orders / production](./04-work-orders-production.md)
-- [Inventory types](./01-inventory-types.md)
+- [Work orders / production](./04-work-orders-production.md) — the build workflow that drives jID 14
+- [History and costing](./02-history-and-costing.md) — how component costs are drawn
+- [Inventory types](./01-inventory-types.md) — `ma`/`sa` vs. `ms`
+- [Journals (the journal_id reference)](../01-phreebooks/02-journals.md#jid-14--assembly-j14php)

--- a/docs/04-modules-in-depth/03-inventory/03-assemblies.md
+++ b/docs/04-modules-in-depth/03-inventory/03-assemblies.md
@@ -2,7 +2,7 @@
 title: Assemblies
 category: Inventory
 order: 3
-status: draft
+status: published
 audience: [bookkeeper, admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/03-inventory/04-work-orders-production.md
+++ b/docs/04-modules-in-depth/03-inventory/04-work-orders-production.md
@@ -2,33 +2,130 @@
 title: Work Orders / Production
 category: Inventory
 order: 4
-status: stub
+status: draft
 audience: [bookkeeper, admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Work Orders / Production
 
-> **Status:** Stub — not yet drafted.
+A **work order** (WO) is the shop-floor side of building an
+[assembly](./03-assemblies.md): it tracks the production steps, who did and checked
+each one, and any data captured along the way — and when the build is done, it
+posts the accounting automatically. This is where Bizuno crosses from "accounting
+app" into **light MRP**.
 
-## What this page will cover
+> **Light** is the operative word. Work orders give you a stepped, signed-off
+> build process with stock allocation — not work centers, routings, capacity
+> planning, or labor capture. Read [Honest scope](#honest-scope) before you commit
+> a real manufacturing operation to it.
 
-- Work-order lifecycle: design → schedule → release → in-progress → complete → close
-- The Production Manager (`inventory/build/manager`) and its child screens (Designer + Tasks)
-- Role security pattern (parent's effective access = max-child access, since the role editor doesn't expose a checkbox for the parent — see `removeOrphanMenus` change in 7.3.9)
-- Capturing labor and overhead onto the work order
-- Partial completions (split a work order)
-- Tying work orders to sales orders (build-to-order)
-- Stop-Work integration with the Quality module
+---
 
-## Why it matters
+## Two records, two jobs
 
-Work orders are where Bizuno crosses from "accounting app" into "light MRP."
-Documentation needs to be careful — over-promise and you draw users who
-needed a real MRP; under-describe and you hide real value.
+| Record                 | Journal | Role                                                  |
+|------------------------|:-------:|------------------------------------------------------|
+| **Work Order**         | jID 32  | The workflow tracker — steps, signoffs, allocation   |
+| **Assembly**           | jID 14  | The GL posting of the actual build                    |
+
+The work order is **planning and execution**; the assembly is the **accounting**.
+When a work-order step that's flagged to post completes, Bizuno creates and posts a
+jID 14 [assembly](./03-assemblies.md#building-what-posts) for you — consuming
+components and producing the finished item. The two are linked by reference number.
+
+---
+
+## The Production Manager
+
+Work orders live under the Production Manager (`inventory/build`), with child
+screens for the step **Designer** and the **Tasks** list. The controller methods
+map to the lifecycle:
+
+| Action            | What it does                                                      |
+|-------------------|------------------------------------------------------------------|
+| `add`             | Start a WO by choosing the assembly SKU to build                  |
+| `edit` / `save`   | Set/adjust quantity and due date; re-allocates components if qty changes |
+| `details`         | Show the production-steps table with the current step highlighted |
+| `saveStep`        | Advance a step — record manufacturing & QA signoffs, capture any required data, and (if the step is flagged) auto-post the jID 14 build |
+| `delete`          | Remove the WO — un-posts the jID 14 if it was already assembled   |
+| `allocateAdj`     | Reserve component stock against open WOs (`qty_alloc`)            |
+
+### Lifecycle and status
+
+A work order's headline state is the `closed` flag (0 = open, 1 = closed), with
+`post_date` as the create date, `terminal_date` as the due date, and `closed_date`
+stamped when the final step completes.
+
+Within a WO, the **production steps** are stored as metadata. Each step carries:
+
+- a **complete** flag,
+- **manufacturing** and **QA** signoffs (`mfg_id` / `qa_id`) with their dates,
+- an optional **captured value** (`data_value`) when the step requires a reading
+  or measurement.
+
+So a build progresses step → step, each one signed off (and optionally
+QA-checked and data-stamped), until the posting step fires the assembly and the
+order closes.
+
+### Component allocation
+
+If a WO is set to allocate, opening it **reserves** its components by raising
+`qty_alloc` on those items — so the stock shows as spoken-for and won't be
+double-committed. Changing the WO quantity re-allocates; deleting or completing it
+releases the reservation. This is how build-to-order coexists with normal sales
+demand on the same stock.
+
+---
+
+## Security: the parent-menu access bridge
+
+Work-order access is governed by the `woProd` security key. There's a wrinkle
+worth knowing if you administer roles:
+
+The role editor only exposes checkboxes for the **leaf** screens (the Designer and
+Tasks children), not for the Production Manager parent. To keep the parent
+reachable, Bizuno (since **7.3.9**, via `removeOrphanMenus()`) gives a routable
+parent menu the **maximum access level of its children** — so granting a user the
+child screens automatically grants the parent it lives under.
+
+Practical upshot: **grant the child permissions and the Production Manager opens**;
+you won't find (or need) a separate checkbox for the parent.
+
+---
+
+## Honest scope
+
+What work orders **do**:
+
+- Stepped builds with manufacturing + QA signoff per step
+- Optional data capture per step
+- Component allocation / reservation (`qty_alloc`)
+- Automatic GL posting of the build (jID 14) on completion
+- Tie a build to the assembly definition for repeatability
+
+What they **don't** do — by design, so you can plan around it:
+
+- **No labor or overhead capture.** Steps record *who* and *when*, but no labor
+  hours or rates feed cost. Build cost is components only (see
+  [Assemblies → Honest limits](./03-assemblies.md#honest-limits)).
+- **No work centers, routings, or capacity/scheduling.** Steps are a checklist,
+  not a routed operation through resources.
+- **No automated Quality "stop-work" link.** The [Quality module](../05-quality/01-ca-pa-tickets.md)
+  has its own stop-work tickets, but there is **no built-in tie** between a quality
+  ticket and a work order — holding a WO for a quality issue is a manual,
+  human-coordinated process, not an automated gate. (If you need that link,
+  it's a customization, not a setting.)
+
+For batch builds, kit assembly, and a documented sign-off trail, this is a genuine
+asset. For full discrete or process manufacturing, treat it as a stepping stone,
+not a destination.
+
+---
 
 ## Related
 
-- [Assemblies](./03-assemblies.md)
-- [CA/PA tickets](../05-quality/01-ca-pa-tickets.md)
-- [Roles and security](../../05-administration/01-roles-and-security.md)
+- [Assemblies](./03-assemblies.md) — the bill of materials and build costing
+- [History and costing](./02-history-and-costing.md) — how component cost is drawn
+- [CA/PA tickets](../05-quality/01-ca-pa-tickets.md) — the (separate) Quality module
+- [Roles and security](../../05-administration/01-roles-and-security.md) — the access model behind `woProd`

--- a/docs/04-modules-in-depth/03-inventory/04-work-orders-production.md
+++ b/docs/04-modules-in-depth/03-inventory/04-work-orders-production.md
@@ -16,9 +16,11 @@ posts the accounting automatically. This is where Bizuno crosses from "accountin
 app" into **light MRP**.
 
 > **Light** is the operative word. Work orders give you a stepped, signed-off
-> build process with stock allocation — not work centers, routings, capacity
-> planning, or labor capture. Read [Honest scope](#honest-scope) before you commit
-> a real manufacturing operation to it.
+> build process with stock allocation — not work centers, routings, or capacity
+> planning. (Labor *cost* you can capture, via labor items on the
+> [bill of materials](./03-assemblies.md#costing-labor-and-overhead).) Read
+> [Honest scope](#honest-scope) before you commit a real manufacturing operation
+> to it.
 
 ---
 
@@ -106,20 +108,40 @@ What work orders **do**:
 
 What they **don't** do — by design, so you can plan around it:
 
-- **No labor or overhead capture.** Steps record *who* and *when*, but no labor
-  hours or rates feed cost. Build cost is components only (see
-  [Assemblies → Honest limits](./03-assemblies.md#honest-limits)).
 - **No work centers, routings, or capacity/scheduling.** Steps are a checklist,
   not a routed operation through resources.
-- **No automated Quality "stop-work" link.** The [Quality module](../05-quality/01-ca-pa-tickets.md)
-  has its own stop-work tickets, but there is **no built-in tie** between a quality
-  ticket and a work order — holding a WO for a quality issue is a manual,
-  human-coordinated process, not an automated gate. (If you need that link,
-  it's a customization, not a setting.)
+- **Labor cost, but not labor *time*.** You can fold labor and overhead **cost**
+  into the build by putting labor items on the
+  [bill of materials](./03-assemblies.md#costing-labor-and-overhead); what steps
+  don't do is capture actual hours worked or feed a time clock.
 
-For batch builds, kit assembly, and a documented sign-off trail, this is a genuine
-asset. For full discrete or process manufacturing, treat it as a stepping stone,
-not a destination.
+For batch builds, kit assembly, itemized labor cost, and a documented sign-off
+trail, this is a genuine asset. For full discrete or process manufacturing with
+routed work centers, treat it as a stepping stone, not a destination.
+
+---
+
+## Quality stop-work and the dashboard
+
+A work order can be halted for a quality problem, and the place that surfaces is
+the **Quality module's stop-work tickets** ([CA/PA tickets](../05-quality/01-ca-pa-tickets.md)).
+There is **no automated data link** between a quality ticket and a specific work
+order — holding a build for a quality issue is a human-coordinated process, not a
+system gate. What gives management *visibility* into it is the **Stop-Work
+dashboard** (`qa_stop_work`), which lists open stop-work tickets at a glance, each
+linking through to the corrective-action record.
+
+> **About dashboards.** A Bizuno dashboard is a summary widget that gives you
+> at-a-glance data on the page where it's relevant. Each dashboard declares a
+> **category** matching a major menu heading (Customers, Vendors, Inventory,
+> Banking, General Ledger, Quality, …), and Bizuno shows it on that heading's
+> landing page; dashboards can also be placed on the **home page** so management
+> sees the most important numbers the moment they log in. A user adds the
+> dashboards they want from the available set for that page.
+>
+> The Stop-Work dashboard ships under the **Quality** category. To put critical
+> safety/quality status in front of management immediately, add it to the **home
+> page** dashboards — that's exactly the kind of summary the home dashboard is for.
 
 ---
 

--- a/docs/04-modules-in-depth/03-inventory/04-work-orders-production.md
+++ b/docs/04-modules-in-depth/03-inventory/04-work-orders-production.md
@@ -2,7 +2,7 @@
 title: Work Orders / Production
 category: Inventory
 order: 4
-status: draft
+status: published
 audience: [bookkeeper, admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/03-inventory/README.md
+++ b/docs/04-modules-in-depth/03-inventory/README.md
@@ -10,7 +10,7 @@ transact.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [Inventory types](./01-inventory-types.md)                            | draft  | bookkeeper, admin |
-| 02 | [History and costing](./02-history-and-costing.md)                    | draft  | bookkeeper, admin |
-| 03 | [Assemblies](./03-assemblies.md)                                      | draft  | bookkeeper, admin |
-| 04 | [Work orders / production](./04-work-orders-production.md)            | draft  | bookkeeper, admin |
+| 01 | [Inventory types](./01-inventory-types.md)                            | published | bookkeeper, admin |
+| 02 | [History and costing](./02-history-and-costing.md)                    | published | bookkeeper, admin |
+| 03 | [Assemblies](./03-assemblies.md)                                      | published | bookkeeper, admin |
+| 04 | [Work orders / production](./04-work-orders-production.md)            | published | bookkeeper, admin |

--- a/docs/04-modules-in-depth/03-inventory/README.md
+++ b/docs/04-modules-in-depth/03-inventory/README.md
@@ -10,7 +10,7 @@ transact.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [Inventory types](./01-inventory-types.md)                            | stub   | bookkeeper, admin |
-| 02 | [History and costing](./02-history-and-costing.md)                    | stub   | bookkeeper, admin |
-| 03 | [Assemblies](./03-assemblies.md)                                      | stub   | bookkeeper, admin |
-| 04 | [Work orders / production](./04-work-orders-production.md)            | stub   | bookkeeper, admin |
+| 01 | [Inventory types](./01-inventory-types.md)                            | draft  | bookkeeper, admin |
+| 02 | [History and costing](./02-history-and-costing.md)                    | draft  | bookkeeper, admin |
+| 03 | [Assemblies](./03-assemblies.md)                                      | draft  | bookkeeper, admin |
+| 04 | [Work orders / production](./04-work-orders-production.md)            | draft  | bookkeeper, admin |


### PR DESCRIPTION
## What

Drafts the full **Inventory** module section (`04-modules-in-depth/03-inventory/`), taking all four stubs to `draft`.

- **Inventory types** — the complete 14-code reference, `INVENTORY_COGS_TYPES`, tracked vs. non-tracked behavior, the `ms`→`mi` master/variant model, and why type/SKU/cost-method lock after the first transaction.
- **History & costing** — the `inventory_history` cost-layer ledger, per-item `cost_method` (FIFO/LIFO/average) and per-type defaults, `auto_cost` (PO/PR), COGS draw on sale (`journal_cogs_usage`), the negative-stock queue (`journal_cogs_owed`) + average re-post, adjustments, and the repair/recalc tools.
- **Assemblies** — `ma`/`sa` `bill_of_materials`, BOM lock after transacting, the jID 14 build posting (`asy`/`asi` legs + component-cost rollup), and **honest limits** (no labor/overhead, non-recursive cost, no phantom assemblies).
- **Work orders / production** — jID 32 workflow vs. jID 14 GL posting, the `inventory/build` lifecycle, step signoffs + data capture, `qty_alloc` allocation, the `woProd` parent-menu access bridge (`removeOrphanMenus`, 7.3.9), and **honest scope** (light MRP).

## Corrections to stub assumptions
Research surfaced two things the stubs overstated, fixed in the prose:
- Assembly cost is **components only** — labor/overhead is not captured.
- The Quality **stop-work "integration" with work orders is not implemented** — Quality is independent; any link is a customization.

## Provenance
Grounded in `controllers/inventory/*`, `phreebooks/journals/*` (common.php, j06/j12/j14/j16), `bizunoCFG.php`, and `model/registry.php`.

## Status
Pages are `status: draft` — not synced to bizuno.com. Review then publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)