### PR TITLE
docs(contacts): Contacts module section

### DIFF
--- a/docs/04-modules-in-depth/04-contacts/01-the-contacts-table.md
+++ b/docs/04-modules-in-depth/04-contacts/01-the-contacts-table.md
@@ -2,31 +2,184 @@
 title: The Contacts Table
 category: Contacts
 order: 1
-status: stub
+status: draft
 audience: [admin, developer]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # The Contacts Table
 
-> **Status:** Stub — not yet drafted.
+Customers, vendors, employees, branches, CRM leads, projects, and login users all
+live in **one table**: `contacts`. What a record *is* depends on which **role
+flags** it carries — and a single record can carry several at once. This is the
+reference page for that table: the fields, the role model, where addresses live,
+and the per-contact defaults that drive posting.
 
-## What this page will cover
+> **One record, many roles.** "Bob's Hardware" who both buys from you and supplies
+> you is **one** contact with both the customer and vendor flags set — not two
+> records. That shared identity (and shared history) is the whole point. See
+> [Contacts as the universal entity](../../02-core-concepts/04-contacts-as-universal-entity.md).
 
-- Full field reference: id, type, ctype_*, gl_acct_c/v, ach_*, terms, currency, tax_rate_id, etc.
-- The `type` field vs. the `ctype_*` boolean flags — historical legacy + current meaning
-- Why `address_book` is a separate table (one contact, many addresses)
-- The `gl_acct_c` and `gl_acct_v` per-contact default AR/AP accounts
-- Marketplace flag (sales tax remittance considerations)
-- Tax exempt setup
-- Restricted-store users — when a contact is locked to one store_id
+---
 
-## Why it matters
+## Role flags
 
-Reference page for developers writing custom journals or reports and admins
-who need to clean up a duplicated customer-vs-vendor mess.
+A contact's roles are independent boolean columns (`ctype_*`):
+
+| Flag       | Role        | Notes                                             |
+|------------|-------------|---------------------------------------------------|
+| `ctype_c`  | Customer    | You sell to them                                  |
+| `ctype_v`  | Vendor      | You buy from them                                 |
+| `ctype_e`  | Employee    | A person you employ (admin-gated)                 |
+| `ctype_b`  | Branch      | A store/branch location                           |
+| `ctype_i`  | CRM contact | A lead/prospect in the CRM                         |
+| `ctype_j`  | Project     | A project/job record                              |
+| `ctype_u`  | User        | A Bizuno **login** (admin-gated)                  |
+
+The code works with these through the `contacts` class: the `ROLES` constant maps
+the letters `c/v/e/b/i/j/u` to the `ctype_*` columns, and helpers like
+`hasRole()`, `getRoles()`, and `isEmployee()` read them. Each role also maps to a
+**security key** — `mgr_c` (customers), `mgr_v` (vendors), `mgr_i` (CRM), `mgr_j`
+(projects), and `admin` for employees and users — so access is granted per role.
+
+> **Legacy note (`type` → `ctype_*`).** Before v7.0 a contact had a single `type`
+> character and could be only one thing. The 7.0 migration spread that into the
+> boolean flags above and renamed the old column `xtype` (no longer used). If you
+> read old code or reports referencing `type`, that's the history.
+
+---
+
+## Field reference
+
+### Identity & status
+
+| Field          | Meaning                                                     |
+|----------------|------------------------------------------------------------|
+| `id`           | Primary key                                                |
+| `short_name`   | The human Contact ID (unique short code)                   |
+| `primary_name` | Business / primary name (required)                         |
+| `contact_first` / `contact_last` / `contact` | Person name / attention   |
+| `flex_field_1` | Title (customers/vendors) or middle name (employees)       |
+| `inactive`     | Status: `0` active, `1` inactive, `2` locked, `H` credit hold |
+| `first_date`   | Record created (used as hire date for employees)           |
+| `date_last`    | Last updated                                               |
+
+### Contact methods
+
+Mailing address is stored **directly on the contact row** (`address1`, `address2`,
+`city`, `state`, `postal_code`, `country`) along with up to four each of
+`telephone1-4`, `email`/`email2-4`, plus `website` and a `newsletter` opt-in flag.
+
+### Business & posting defaults
+
+| Field          | Meaning                                                          |
+|----------------|-----------------------------------------------------------------|
+| `account_number` | Their account number for you (vendor-assigned, etc.)          |
+| `rep_id`       | The assigned rep/user                                           |
+| `store_id`     | The store this contact belongs to                              |
+| `terms`        | Encoded payment terms — and the credit limit (see [Customers](./02-customers.md#credit-limit-and-hold)) |
+| `price_sheet`  | Default price level (references an inventory price sheet)        |
+| `gl_account`   | Default income/expense line account                            |
+| `gl_acct_c`    | Customer **AR** control account default                         |
+| `gl_acct_v`    | Vendor **AP** control account default                          |
+
+When a transaction line for this contact doesn't specify a GL account, these
+defaults fill in — `gl_acct_c`/`gl_acct_v` for the AR/AP control side, `gl_account`
+for the revenue/expense side. They seed from the
+[PhreeBooks module defaults](../01-phreebooks/01-chart-of-accounts.md#default-accounts--why-posting-just-works)
+when the contact is created.
+
+### Tax
+
+| Field         | Meaning                                                           |
+|---------------|------------------------------------------------------------------|
+| `tax_rate_id` | Default sales-tax authority for this contact                     |
+| `tax_exempt`  | `1` = no tax calculated on this contact's transactions           |
+| `marketplace` | Flags a customer as a marketplace that remits tax itself         |
+
+> **`marketplace` is a flag, not behavior (yet).** The column exists and you can
+> set it, but no posting logic currently keys off it to change tax treatment —
+> treat it as a label for now, not an automated marketplace-facilitator
+> pass-through.
+
+### ACH banking
+
+`ach_enable`, `ach_bank`, `ach_routing`, `ach_account` hold the bank details used
+for [ACH vendor payments / customer drafts](./03-vendors.md#ach-payments). These
+fields are **excluded from export** and their panel is gated behind the
+`admin_encrypt` profile permission, so they're not shown to ordinary users.
+
+> **Be precise about "encrypted."** The ACH columns are *access-restricted* and
+> never exported — but the table schema doesn't define column-level encryption at
+> rest. If your deployment needs encryption-at-rest for bank details, treat it as
+> a hosting/database concern, not something the schema guarantees.
+
+### `gov_id_number`
+
+A generic government ID (SSN for an employee, tax ID for a vendor). It's a single
+free-text field — there is **no** structured 1099/W-9 handling built on it (see
+[Vendors → 1099](./03-vendors.md#1099--w-9)).
+
+---
+
+## Where addresses live
+
+A contact has **one primary address on the row** (the mailing address) and **any
+number of additional addresses in `contacts_meta`**, keyed by purpose:
+
+| Meta key    | Address                          |
+|-------------|----------------------------------|
+| `address_b` | Billing                          |
+| `address_s` | Shipping / ship-to (branches)    |
+| `address_i` | CRM detail contacts              |
+
+So one customer can have many ship-to addresses without duplicating the contact.
+The `getAddresses($type)` helper reads them.
+
+> **Legacy note (`address_book`).** Pre-7.0, addresses lived in a separate
+> `address_book` table. The 7.0 migration denormalized the primary address onto
+> the contact row and moved the rest into `contacts_meta`. If you see
+> `address_book` referenced anywhere, it's the old model.
+
+---
+
+## Store restriction and rep locking
+
+Two mechanisms scope who sees which contacts:
+
+- **`store_id`** ties a contact to a store. A user with restricted store access
+  only sees (and creates) contacts in their store, and new contacts are locked to
+  it.
+- **`restrict_user`** (a user profile flag) limits a user to contacts where
+  `rep_id` matches their own user ID — a salesperson sees only their accounts.
+
+---
+
+## Related meta and log tables
+
+- **`contacts_meta`** — flexible per-contact key/value data: the extra addresses
+  above, `pay_rate` (employees), `crm_project` (projects), price-level meta, and
+  more.
+- **`contacts_log`** — the per-contact activity/audit trail (CRM actions, changes),
+  with `log_date`, `entered_by`, `action`, and `notes`.
+
+---
+
+## Cleaning up a duplicated customer-vs-vendor mess
+
+Because one entity should be one record, the classic cleanup is merging a contact
+that was entered twice — once as a customer, once as a vendor. The right end state
+is a single record with **both** `ctype_c` and `ctype_v` set. Re-point historical
+transactions to the surviving `id`, set both role flags, copy across the
+`gl_acct_c` / `gl_acct_v` defaults, and retire (mark inactive) the duplicate.
+Don't delete a contact that still has journal history — its postings reference its
+`id`.
+
+---
 
 ## Related
 
 - [Contacts as the universal entity](../../02-core-concepts/04-contacts-as-universal-entity.md)
+- [Customers](./02-customers.md) · [Vendors](./03-vendors.md) · [Employees](./04-employees.md)
 - [Users vs. employees vs. contacts](../../05-administration/02-users-employees-contacts.md)
+- [Chart of Accounts](../01-phreebooks/01-chart-of-accounts.md) — the GL defaults these fields point at

--- a/docs/04-modules-in-depth/04-contacts/01-the-contacts-table.md
+++ b/docs/04-modules-in-depth/04-contacts/01-the-contacts-table.md
@@ -2,7 +2,7 @@
 title: The Contacts Table
 category: Contacts
 order: 1
-status: draft
+status: published
 audience: [admin, developer]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/04-contacts/02-customers.md
+++ b/docs/04-modules-in-depth/04-contacts/02-customers.md
@@ -2,7 +2,7 @@
 title: Customers
 category: Contacts
 order: 2
-status: draft
+status: published
 audience: [bookkeeper]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/04-contacts/02-customers.md
+++ b/docs/04-modules-in-depth/04-contacts/02-customers.md
@@ -2,32 +2,106 @@
 title: Customers
 category: Contacts
 order: 2
-status: stub
+status: draft
 audience: [bookkeeper]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Customers
 
-> **Status:** Stub — not yet drafted.
+A customer is a [contact](./01-the-contacts-table.md) with the customer role
+(`ctype_c`) set. This page is the bookkeeper's path: add one fast, then layer on
+the optional setup (terms, tax exemption, ship-to branches, pricing) only if you
+need it.
 
-## What this page will cover
+---
 
-- Setting up a new customer (the bookkeeper's path, not the full schema reference)
-- Default terms, default GL accounts, tax exemption setup
-- Branches / ship-to addresses
-- Credit limits + holds
-- Customer-specific pricing (per-customer price levels)
-- Aged AR per customer
-- Reading the contact history grid (sales, payments, returns, support tickets)
+## Add a customer — the fast path
 
-## Why it matters
+*Customers → Customers → New.* The only things you truly need are a **Contact ID**
+(`short_name`) and a **primary name**; everything else has a sensible default:
 
-The "add a customer" page is one of the first things a new user hits.
-Doc should make the common path fast and surface the optional setup
-(branches, pricing) without making it look mandatory.
+- **Default GL / revenue account** seeds from *Settings → PhreeBooks → Customers*
+  (`gl_sales`); the AR control account from the same place (`gl_acct_c`).
+- **Default tax authority** (`tax_rate_id`) seeds from the customer tax default.
+- **Sales rep** (`rep_id`) — optional; drives rep filtering and commission reports.
+
+Save and you can immediately quote, order, and invoice them.
+
+---
+
+## Terms
+
+The **terms** control sets the payment expectation (Net 30, Due on receipt, etc.)
+and seeds the due date on every invoice. Edit them from the customer's terms
+dialog (the gear next to the terms field). Terms are stored encoded on the contact
+and can be overridden per transaction at entry time.
+
+---
+
+## Credit limit and hold
+
+The customer's **credit limit** is carried inside the terms data (default 1000).
+Two things to understand about how Bizuno uses it:
+
+- **It's a warning, not a wall.** When a customer's open AR exceeds their credit
+  limit, the order/entry screen shows a **yellow status** flag. Bizuno does **not**
+  block new orders over the limit — the decision stays with you.
+- **Credit hold** is the `inactive = H` status. It marks the account on hold
+  (shown highlighted in the customer list) but, likewise, is a flag for humans
+  rather than an automated gate.
+
+If you need hard enforcement (refuse to save an over-limit order), that's a
+customization, not a built-in setting.
+
+---
+
+## Tax exemption
+
+Set **`tax_exempt`** on a customer (e.g. a reseller with a resale certificate) and
+no sales tax is calculated on their transactions. For a customer who is itself a
+marketplace, there's a `marketplace` flag — but note it's currently a label only
+and doesn't change tax posting (see
+[The contacts table](./01-the-contacts-table.md#tax)).
+
+---
+
+## Ship-to addresses (branches)
+
+A customer keeps **one billing address on the record** and **any number of ship-to
+addresses** alongside it (stored as `address_s` entries). Add a ship-to per branch
+or delivery point from the customer's address tab; pick the right one at order
+time. You don't create a separate contact per delivery location.
+
+(There is also a distinct **Branch** contact role, `ctype_b`, for modeling store
+locations — different from a customer's multiple ship-to addresses.)
+
+---
+
+## Customer pricing
+
+A customer can be assigned a **price sheet** (`price_sheet`) — a price level that
+overrides default item pricing for that customer. Pricing is **sheet-based**:
+assign the customer to a sheet and they get those prices. It is *not* a dynamic
+volume/date tier engine — it's a static level you manage in the
+[inventory pricing](../03-inventory/01-inventory-types.md) setup and attach here.
+
+---
+
+## Aged AR and history
+
+- **Aged receivables** for a customer come from the open sales invoices and credit
+  memos (journals 12 and 13), bucketed by due date. The status panel on the
+  customer (and the Aged Receivables dashboard) shows current / 1-30 / 31-60 /
+  61-90 / 91-120 / over-120 / total.
+- **History grids** on the customer's History tab show their quotes (jID 9), sales
+  orders (jID 10), and invoices (jID 12), plus a payment-history view — the full
+  trail for that account in one place.
+
+---
 
 ## Related
 
-- [The contacts table](./01-the-contacts-table.md)
+- [The contacts table](./01-the-contacts-table.md) — the underlying fields
+- [Vendors](./03-vendors.md) — the buying-side mirror
 - [Quote → SO → Invoice → Payment → Deposit](../../03-daily-workflows/01-quote-so-invoice-payment-deposit.md)

--- a/docs/04-modules-in-depth/04-contacts/03-vendors.md
+++ b/docs/04-modules-in-depth/04-contacts/03-vendors.md
@@ -2,7 +2,7 @@
 title: Vendors
 category: Contacts
 order: 3
-status: draft
+status: published
 audience: [bookkeeper]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/04-contacts/03-vendors.md
+++ b/docs/04-modules-in-depth/04-contacts/03-vendors.md
@@ -2,31 +2,89 @@
 title: Vendors
 category: Contacts
 order: 3
-status: stub
+status: draft
 audience: [bookkeeper]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Vendors
 
-> **Status:** Stub — not yet drafted.
+A vendor is a [contact](./01-the-contacts-table.md) with the vendor role
+(`ctype_v`) set — the buying-side mirror of a [customer](./02-customers.md). Most
+of the setup is identical; this page focuses on the vendor-specific parts (default
+expense account, ACH payment details, the 1099 reality, aged AP).
 
-## What this page will cover
+---
 
-- Setting up a new vendor
-- Default terms, default GL accounts, default expense account
-- 1099 / W-9 tracking (US tax form support)
-- ACH banking info (encrypted at rest)
-- Marketplace facilitator flag (sales-tax-collected pass-through)
-- Aged AP per vendor
-- Vendor history grid
+## Add a vendor
 
-## Why it matters
+*Vendors → Vendors → New.* As with customers, you need a **Contact ID** and a
+**primary name**; the rest defaults:
 
-Mirror of [Customers](./02-customers.md), but with vendor-side specifics
-(1099, banking, marketplace flag) that confuse first-time users.
+- **Default GL / expense account** seeds from *Settings → PhreeBooks → Vendors*
+  (`gl_expense`); the AP control account from `gl_acct_v`.
+- **Default tax authority** from the vendor tax default.
+- **Terms** set the bill due date.
+- **`account_number`** is your account number *with that vendor*.
+
+---
+
+## ACH payments
+
+To pay a vendor electronically, set up their bank details on the vendor record:
+`ach_enable`, `ach_bank`, `ach_routing`, `ach_account`. When you run
+[Pay Bills (jID 20)](../01-phreebooks/02-journals.md#jid-20--pay-bills-j20php), the
+bulk/ACH check run picks up ACH-enabled vendors and builds the NACHA file; non-ACH
+vendors get printed checks with incrementing numbers.
+
+> **Sensitivity.** Bank fields are excluded from exports and hidden behind the
+> `admin_encrypt` profile permission, so they're not visible to ordinary users.
+> They are *access-restricted*, but the schema doesn't itself encrypt them at rest
+> — if you need at-rest encryption, handle it at the database/hosting layer. See
+> [The contacts table → ACH](./01-the-contacts-table.md#ach-banking).
+
+---
+
+## 1099 / W-9
+
+Be aware of the gap here: **Bizuno core has no structured 1099 or W-9 tracking.**
+There is a single generic `gov_id_number` field (which doubles as SSN for
+employees and tax ID for vendors), but **no 1099 vendor flag, no box mapping, and
+no 1099/1096 generation.**
+
+If you need to issue 1099-NECs:
+
+- Record the tax ID in `gov_id_number` and flag your 1099 vendors however you
+  track them (a naming convention, a custom field, or a report filter).
+- Pull the year's payments per vendor with a [PhreeForm](../02-phreeform/01-report-engine-overview.md)
+  report and file through your tax service or accountant.
+
+Don't expect a one-click 1099 run — it isn't there.
+
+---
+
+## Marketplace flag
+
+The `marketplace` column exists on contacts, but as noted on
+[the table page](./01-the-contacts-table.md#tax) it currently has no posting
+behavior wired to it. Treat it as a label, not an automated sales-tax pass-through.
+
+---
+
+## Aged AP and history
+
+- **Aged payables** come from open vendor bills and credits (journals 6 and 7),
+  bucketed by due date — the same aging engine as the customer side, pointed at
+  the payables journals.
+- **History grids** on the vendor's History tab show their RFQs (jID 3), purchase
+  orders (jID 4), and bills (jID 6), with the payment trail — the full account
+  history in one view.
+
+---
 
 ## Related
 
 - [The contacts table](./01-the-contacts-table.md)
-- [PO → Receive → Vendor Invoice → Pay Bill](../../03-daily-workflows/02-po-receive-bill-pay.md)
+- [Customers](./02-customers.md) — the selling-side mirror
+- [Pay Bills (jID 20)](../01-phreebooks/02-journals.md#jid-20--pay-bills-j20php)
+- [PO → Receive → Bill → Pay](../../03-daily-workflows/02-po-receive-bill-pay.md)

--- a/docs/04-modules-in-depth/04-contacts/04-employees.md
+++ b/docs/04-modules-in-depth/04-contacts/04-employees.md
@@ -2,7 +2,7 @@
 title: Employees
 category: Contacts
 order: 4
-status: draft
+status: published
 audience: [bookkeeper, admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/04-contacts/04-employees.md
+++ b/docs/04-modules-in-depth/04-contacts/04-employees.md
@@ -2,31 +2,103 @@
 title: Employees
 category: Contacts
 order: 4
-status: stub
+status: draft
 audience: [bookkeeper, admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Employees
 
-> **Status:** Stub — not yet drafted.
+An employee is a [contact](./01-the-contacts-table.md) with the employee role
+(`ctype_e`) set. The most important thing to understand on this page isn't a field
+— it's the distinction between an **employee** and a **user**, which trips up
+almost everyone the first time.
 
-## What this page will cover
+> **Employee ≠ User.** Being an employee does not give someone a login, and having
+> a login does not make someone an employee. They are two independent role flags on
+> the contact record. See [Employee vs. user](#employee-vs-user).
 
-- Employee setup: `ctype_e` contact + employment fields
-- Connection between an `Employee` (contact) and a `User` (Bizuno login)
-- Pay rate, default pay-period
-- Tax withholding profiles (W-4 in the US)
-- Department / role for time-tracking and labor-rate-by-employee
-- Hire / termination dates and how they affect payroll runs
-- HR records that survive after termination
+---
 
-## Why it matters
+## Employee setup
 
-Many small businesses don't separate "employee" from "Bizuno user" cleanly,
-which causes role-security mistakes. Doc should call this out explicitly.
+*Employees → Employees → New* creates a contact with `ctype_e`. The employee form
+surfaces the fields that matter for a person record:
+
+- **Name** — `contact_first`, `contact_last`, and `flex_field_1` (used as the
+  middle name for employees).
+- **Contact ID** (`short_name`) — the employee ID.
+- **`gov_id_number`** — SSN / government ID.
+- **`account_number`** — doubles as the employee's sign-off PIN (used for
+  production step sign-offs, see [Work orders](../03-inventory/04-work-orders-production.md)).
+- **`store_id`** — the employee's store.
+- **`first_date`** — record creation, used as the hire date; address, phones,
+  email as usual.
+
+A **pay rate** can be stored in the employee's metadata (`pay_rate`), and
+**training** records likewise live in contact metadata.
+
+Employee records are **admin-gated** (the `admin` security key), since they hold
+personal data.
+
+---
+
+## What employees do *not* hold
+
+Bizuno core has **no payroll setup on the employee record** — no pay-period
+configuration, no W-4 / withholding profile, no deduction templates. That's not an
+oversight to work around; it's because **Bizuno doesn't run payroll** — it imports
+finished payroll from a provider and posts it to the General Journal. See
+[Payroll](../01-phreebooks/04-payroll.md) for the full picture. The employee
+record is for identity, assignment, and HR reference, not for computing pay.
+
+---
+
+## Employee vs. user
+
+This is the distinction to internalize:
+
+| | **Employee** (`ctype_e`) | **User** (`ctype_u`) |
+|---|---|---|
+| What it is | A person you employ | A Bizuno **login** |
+| Grants a login? | No | Yes |
+| Has a password / profile? | No | Yes (`user_profile` metadata + auth) |
+| Security to manage | `admin` | `admin` |
+
+They are separate flags **on the same kind of record**, and a single contact can
+be both — your bookkeeper is typically an employee *and* a user. But:
+
+- A **warehouse employee** who never logs in is an employee with **no** user flag —
+  don't create a login you don't need.
+- An **external accountant** with a login but not on your payroll is a user with
+  **no** employee flag.
+
+> **Why it matters for security.** Treating "employee" and "user" as the same thing
+> leads to role-permission mistakes — either giving logins to people who shouldn't
+> have them, or assuming an employee can sign in when they have no user account.
+> Grant the **user** role (and a role's permissions) deliberately, separately from
+> recording someone as an employee. See
+> [Users vs. employees vs. contacts](../../05-administration/02-users-employees-contacts.md).
+
+---
+
+## Hire / termination and HR continuity
+
+`first_date` serves as the hire date; termination is handled by marking the
+employee **inactive** rather than deleting them. There's **no automated
+date-driven behavior** (no termination triggers, no date-based payroll cutoffs in
+core) — the dates are records, not automation.
+
+Because everyone lives in the one contacts table, an employee who leaves — or who
+becomes a contractor — keeps their record and history. Flip the roles (drop
+`ctype_e`, perhaps add `ctype_v`) rather than starting over; the HR and
+transaction history stays intact.
+
+---
 
 ## Related
 
+- [The contacts table](./01-the-contacts-table.md)
 - [Users vs. employees vs. contacts](../../05-administration/02-users-employees-contacts.md)
-- [Payroll](../01-phreebooks/04-payroll.md)
+- [Payroll](../01-phreebooks/04-payroll.md) — why there's no pay calc here
+- [Work orders / production](../03-inventory/04-work-orders-production.md) — employee step sign-offs

--- a/docs/04-modules-in-depth/04-contacts/05-projects-and-crm.md
+++ b/docs/04-modules-in-depth/04-contacts/05-projects-and-crm.md
@@ -2,7 +2,7 @@
 title: Projects and CRM
 category: Contacts
 order: 5
-status: draft
+status: published
 audience: [bookkeeper]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/04-contacts/05-projects-and-crm.md
+++ b/docs/04-modules-in-depth/04-contacts/05-projects-and-crm.md
@@ -2,30 +2,113 @@
 title: Projects and CRM
 category: Contacts
 order: 5
-status: stub
+status: draft
 audience: [bookkeeper]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Projects and CRM
 
-> **Status:** Stub — not yet drafted.
+Bizuno's CRM and project tracking ride on the same contacts table as everything
+else — a project is a contact (`ctype_j`), a lead is a contact (`ctype_i`). This
+page covers the sales-pipeline and follow-up features, and is honest about where
+"project accounting" stops.
 
-## What this page will cover
+> **Set expectations up front.** Project tracking here is a **pipeline and
+> reference** tool, not a project-ledger. There is **no `project_id` on journal
+> transactions**, so Bizuno does not natively roll invoices/POs/time into a
+> per-project P&L. See [The limits of project accounting](#the-limits-of-project-accounting).
 
-- The `ctype_j` (project) flag — a project is a contact whose other-contacts are linked via relationship rows
-- Promotional campaigns (`crmPromos`) and per-customer history
-- CRM action codes (set in `options_crm_actions`) — outreach types, follow-ups
-- Reminder system for sales follow-ups
-- The light project-accounting model: tie invoices, POs, time to a project_id
-- Profitability reporting per project
+---
 
-## Why it matters
+## Projects (`ctype_j`)
 
-Project tracking is a "we sort of do this" feature in many small accounting
-apps. Bizuno's model is more capable than typical — but only if users
-realize it exists.
+A project is created as a contact carrying the project role, with its detail stored
+in metadata (`crm_project`). The project record holds:
+
+- **`proj_num`** — an auto-assigned project number
+- **`title`** — the project name
+- **`contact_id`** — the customer the project belongs to
+- **`status`** — a sales/delivery pipeline stage (prospect → contacting →
+  point-of-contact identified → follow-up → quote → sale → engineering → doc
+  development → closed / no-opportunity)
+- **`market`**, **`assigned_to`**, **`working_by`** — classification and ownership
+- **`reminder_date`** and **`notes`** — follow-up scheduling and free notes
+
+So a project is essentially an opportunity/job attached to a customer, moved
+through a status pipeline.
+
+---
+
+## CRM contacts and outreach
+
+### Leads (`ctype_i`)
+
+CRM contacts are leads/prospects flagged `ctype_i`, managed under the `mgr_i`
+permission. They're contacts you're working but haven't necessarily transacted
+with yet.
+
+### Action codes
+
+Outreach is logged with **CRM action codes**, configured in
+`options_crm_actions`. The shipped set:
+
+| Code   | Meaning       |
+|--------|---------------|
+| `new`  | New call      |
+| `ret`  | Return call   |
+| `flw`  | Follow up     |
+| `lead` | New lead      |
+| `trn`  | Training      |
+| `inac` | Inactive      |
+
+Each logged action is written to **`contacts_log`** (date, who, action, notes), so
+a contact accumulates an outreach history.
+
+### Campaigns
+
+Promotional email **campaigns** live in their own table (`crmPromos`) — a campaign
+has a title, start/end dates, subject, and body, and targets contacts who've opted
+into the newsletter (or a chosen distribution). Sends are tracked per campaign in
+`crmPromos_history`.
+
+### Reminders / follow-ups
+
+The **CRM Reminder dashboard** surfaces follow-ups whose `reminder_date` has
+arrived, moving due items into the rep's current reminder list (with optional
+recurrence). This is how sales follow-ups stay visible — set a reminder date on a
+project or lead and it surfaces on the dashboard when due. (For how dashboards
+appear per menu heading and on the home page, see
+[Work orders → dashboards](../03-inventory/04-work-orders-production.md#quality-stop-work-and-the-dashboard).)
+
+---
+
+## The limits of project accounting
+
+This is the part to be clear-eyed about. Projects are linked to a **customer**, not
+to **transactions**:
+
+- **No `project_id` on `journal_main`.** Invoices, POs, and other postings record a
+  `contact_id`, not a project. So you cannot tag a specific invoice line to a
+  project out of the box.
+- **No built-in per-project P&L.** Because transactions aren't project-stamped,
+  there's no native "profitability by project" report.
+- **No core time tracking** feeding project cost.
+
+What you *can* do: track the opportunity/job through its pipeline, schedule
+follow-ups, and — if a customer maps one-to-one to a project — aggregate that
+customer's transactions with a [PhreeForm](../02-phreeform/01-report-engine-overview.md)
+report. True multi-project-per-customer cost rollups would require a customization
+that stamps a project reference onto transactions.
+
+> Use projects for **pipeline and CRM**. If you need job-costing across many
+> projects per customer, scope that as an extension rather than expecting it from
+> the box.
+
+---
 
 ## Related
 
 - [The contacts table](./01-the-contacts-table.md)
+- [Customers](./02-customers.md)
+- [PhreeForm](../02-phreeform/01-report-engine-overview.md) — for ad-hoc project/customer reports

--- a/docs/04-modules-in-depth/04-contacts/README.md
+++ b/docs/04-modules-in-depth/04-contacts/README.md
@@ -14,8 +14,8 @@ for the conceptual reasoning before drilling into the per-role pages below.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [The contacts table](./01-the-contacts-table.md)                      | stub   | admin, developer |
-| 02 | [Customers](./02-customers.md)                                        | stub   | bookkeeper     |
-| 03 | [Vendors](./03-vendors.md)                                            | stub   | bookkeeper     |
-| 04 | [Employees](./04-employees.md)                                        | stub   | bookkeeper, admin |
-| 05 | [Projects and CRM](./05-projects-and-crm.md)                          | stub   | bookkeeper     |
+| 01 | [The contacts table](./01-the-contacts-table.md)                      | draft  | admin, developer |
+| 02 | [Customers](./02-customers.md)                                        | draft  | bookkeeper     |
+| 03 | [Vendors](./03-vendors.md)                                            | draft  | bookkeeper     |
+| 04 | [Employees](./04-employees.md)                                        | draft  | bookkeeper, admin |
+| 05 | [Projects and CRM](./05-projects-and-crm.md)                          | draft  | bookkeeper     |

--- a/docs/04-modules-in-depth/04-contacts/README.md
+++ b/docs/04-modules-in-depth/04-contacts/README.md
@@ -14,8 +14,8 @@ for the conceptual reasoning before drilling into the per-role pages below.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [The contacts table](./01-the-contacts-table.md)                      | draft  | admin, developer |
-| 02 | [Customers](./02-customers.md)                                        | draft  | bookkeeper     |
-| 03 | [Vendors](./03-vendors.md)                                            | draft  | bookkeeper     |
-| 04 | [Employees](./04-employees.md)                                        | draft  | bookkeeper, admin |
-| 05 | [Projects and CRM](./05-projects-and-crm.md)                          | draft  | bookkeeper     |
+| 01 | [The contacts table](./01-the-contacts-table.md)                      | published | admin, developer |
+| 02 | [Customers](./02-customers.md)                                        | published | bookkeeper     |
+| 03 | [Vendors](./03-vendors.md)                                            | published | bookkeeper     |
+| 04 | [Employees](./04-employees.md)                                        | published | bookkeeper, admin |
+| 05 | [Projects and CRM](./05-projects-and-crm.md)                          | published | bookkeeper     |


### PR DESCRIPTION
## What

Drafts the full **Contacts** module section (`04-modules-in-depth/04-contacts/`), all five stubs → `draft`.

- **The contacts table** — the `ctype_*` role model (one record, many roles), the legacy `type`→`ctype` migration, full field reference, the address model (primary on the row + `contacts_meta` for billing/ship-to/CRM; `address_book` is pre-7.0 legacy), `gl_acct_c`/`gl_acct_v` posting defaults, tax/ACH fields, store/rep restriction, and the duplicate customer-vs-vendor cleanup.
- **Customers** — fast-add path, terms, credit limit/hold, tax exemption, ship-to addresses, price sheets, aged AR + history.
- **Vendors** — setup, ACH payment details, aged AP + history.
- **Employees** — setup, the employee-vs-user distinction, hire/term, payroll-is-import-only.
- **Projects & CRM** — `ctype_j` pipeline, `ctype_i` leads, CRM action codes, `crmPromos` campaigns, `contacts_log`, the reminder dashboard.

## Corrections to stub assumptions (verified against code)
- **No structured 1099/W-9** — only a generic `gov_id_number`. Documented honestly with a PhreeForm workaround.
- **`marketplace` flag is not enforced** — label only, no tax-posting behavior.
- **Credit limit is a warning, not a block** — yellow status, no order prevention.
- **No `project_id` on `journal_main`** — so no built-in per-project P&L; projects are pipeline/CRM, not a job-cost ledger.
- **`address_book` is legacy** — addresses now live on the contact row + `contacts_meta`.
- **ACH fields are access-gated/export-excluded, not schema-encrypted** — corrected the "encrypted at rest" assumption.

## Provenance
Grounded in `controllers/contacts/*`, `install/tables.php`, `migrate-7.0.php`, and `payment/nacha.php`.

## Status
Pages are `status: draft` — not synced to bizuno.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)