### PR TITLE
docs(phreeform): PhreeForm module section

### DIFF
--- a/docs/04-modules-in-depth/02-phreeform/01-report-engine-overview.md
+++ b/docs/04-modules-in-depth/02-phreeform/01-report-engine-overview.md
@@ -2,31 +2,135 @@
 title: Report Engine Overview
 category: PhreeForm
 order: 1
-status: stub
+status: draft
 audience: [bookkeeper, admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Report Engine Overview
 
-> **Status:** Stub — not yet drafted.
+PhreeForm is Bizuno's **only** reporting and document engine, and it's two tools
+sharing one foundation:
 
-## What this page will cover
+- a **report engine** — tabular output with grouping, totals, and filters, rendered
+  to PDF, HTML, or CSV; and
+- a **form engine** — pixel-positioned documents (invoices, packing slips,
+  statements, checks, labels) rendered to PDF.
 
-- PhreeForm = reports + forms, sharing a designer and data-binding system
-- The report lifecycle: SQL → result set → field merge → render (HTML | PDF | CSV | Excel)
-- Built-in reports vs. user-created reports
-- Per-field grouping, totaling, processing, formatting
-- Output channels: download, email, print
-- Where the report definition is stored (`phreeform` table) and what the JSON struct contains
-- The 7.3.9 tFPDF migration — what changed for end users (mostly nothing visible; barcodes now via picqer; HTML in cells via the in-tree shim)
+Both are built on the same data-binding, processing, and formatting system, so once
+you understand one you understand the other. Learn PhreeForm and you can produce
+almost any document or report your business needs; ignore it and you're stuck with
+the built-ins.
 
-## Why it matters
+---
 
-PhreeForm is the *only* report engine in Bizuno. Mastery here unlocks a lot
-of custom value; ignorance traps users in the built-in reports.
+## How a report runs
+
+```
+ definition (JSON)
+      │  load
+      ▼
+   build SQL  ──►  run query  ──►  per-cell: process → format  ──►  render  ──►  deliver
+ (tables, fields,    (result        (viewProcess then          (PDF │ HTML │   (inline │
+  filters, dates,     rows)          viewFormat)                CSV │ form-PDF)  download │
+  groups, sorts)                                                                 email)
+```
+
+1. **Load the definition.** The report/form is a JSON structure (see
+   [where definitions live](#where-definitions-live)).
+2. **Build the SQL.** PhreeForm assembles `SELECT`/`FROM`/`JOIN`/`WHERE`/`GROUP
+   BY`/`ORDER BY` from the definition's table list, visible fields, user-chosen
+   filters, the date range, and any grouping/sorting (`BuildSQL`).
+3. **Run and merge.** It executes the query and walks the result set, applying each
+   field's **processing** then **formatting** to every cell, and building group
+   subtotals and report totals (`BuildDataArray`). See
+   [Processors and formatters](./04-processors-and-formatters.md).
+4. **Render** to the chosen output.
+5. **Deliver** — display inline, download, or email.
+
+---
+
+## Output formats
+
+| Output | Reports | Forms | Notes                                   |
+|--------|:-------:|:-----:|-----------------------------------------|
+| PDF    | ✓       | ✓     | The default; forms are **PDF only**     |
+| HTML   | ✓       | —     | Tabular reports rendered as an HTML table |
+| CSV    | ✓       | —     | Comma-delimited export (the "xls" toolbar icon) |
+
+You pick the format from the toolbar when you open a report; forms always render to
+PDF.
+
+### Delivery channels
+
+The delivery selector offers:
+
+- **Inline** (`I`) — open in the browser (then print with the browser's print).
+- **Download** (`D`) — save the file.
+- **Email** (`S`) — send it as an attachment via Bizuno's mailer, with optional
+  logging to the contact's activity log.
+
+There is no separate "print" pipeline — printing is "inline, then print from the
+browser/PDF viewer."
+
+---
+
+## Where definitions live
+
+> **Not a `phreeform` table.** Despite the name, report and form definitions are
+> stored in the shared **`common_meta`** table under the `phreeform` key, as JSON.
+> A companion `phreeform_cache` meta entry holds a lightweight index (titles,
+> groups, IDs) so the report tree loads fast without parsing every definition.
+
+A definition's JSON carries everything the engine needs: the `title`, a `type`
+(`rpt` report, `frm` form, `lst` list, `dir` folder), the `group_id` (which folder/
+context it belongs to — see [Custom forms](./05-custom-forms.md#form-groups)), the
+source `tables` with their joins, the `fieldlist`, plus `grouplist`, `sortlist`,
+`filterlist`, page setup, fonts, and an email template.
+
+### Built-in vs. your own
+
+- **Built-in** reports and forms ship as JSON files under `locale/<lang>/reports/`
+  and are imported at install.
+- **Your own** are created in the designer (or by copying a built-in) and saved
+  into `common_meta`. They can be [exported and imported](./05-custom-forms.md#export--import)
+  as JSON to move between installs.
+
+---
+
+## Reports are offered by context
+
+A report or form belongs to a **group**, and groups map to journals/modules — so
+the right documents show up in the right place. When you print from a sales invoice
+(`jID 12`), Bizuno offers the forms in the `cust:j12` group; a check run offers
+`bnk:j20`. The mapping is `getDefaultFormID()`; the full group list is in
+[Custom forms](./05-custom-forms.md#form-groups).
+
+---
+
+## The 7.3.9 PDF migration
+
+As of 7.3.9, PDF generation uses **[tFPDF](https://www.fpdf.org/)** exclusively —
+TCPDF was removed. For end users this is **mostly invisible**, but three details
+matter if you maintain custom forms:
+
+- **Barcodes** are generated by `picqer/php-barcode-generator` (the `bizBarcode()`
+  helper). Supported symbologies include C128 (and A/B/C), C39, EAN-13/8, UPC-A/E,
+  Interleaved 2-of-5, and POSTNET.
+- **HTML inside cells** is handled by an in-tree shim (`bizHTMLCell()`) supporting a
+  small tag set — `<b>/<strong>`, `<i>/<em>`, `<u>`, `<font color>`, and
+  `<p>`/`<div>`/`<br>` as line breaks. Unsupported tags are stripped, not dropped
+  with their text.
+- **PDF page import** (e.g. appending attachments) uses the FPDI tFPDF adapter.
+
+If a custom form renders oddly after upgrading, these are the usual suspects — see
+[Custom forms → troubleshooting](./05-custom-forms.md#troubleshooting-after-739).
+
+---
 
 ## Related
 
 - [Form designer](./02-form-designer.md)
 - [Data binding and fields](./03-data-binding-and-fields.md)
+- [Processors and formatters](./04-processors-and-formatters.md)
+- [Custom forms](./05-custom-forms.md)

--- a/docs/04-modules-in-depth/02-phreeform/01-report-engine-overview.md
+++ b/docs/04-modules-in-depth/02-phreeform/01-report-engine-overview.md
@@ -2,7 +2,7 @@
 title: Report Engine Overview
 category: PhreeForm
 order: 1
-status: draft
+status: published
 audience: [bookkeeper, admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/02-phreeform/02-form-designer.md
+++ b/docs/04-modules-in-depth/02-phreeform/02-form-designer.md
@@ -2,7 +2,7 @@
 title: Form Designer
 category: PhreeForm
 order: 2
-status: draft
+status: published
 audience: [admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/02-phreeform/02-form-designer.md
+++ b/docs/04-modules-in-depth/02-phreeform/02-form-designer.md
@@ -2,32 +2,124 @@
 title: Form Designer
 category: PhreeForm
 order: 2
-status: stub
+status: draft
 audience: [admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Form Designer
 
-> **Status:** Stub — not yet drafted.
+The form designer is where you lay out pixel-positioned documents — invoices,
+packing slips, statements, checks, labels — by placing fields on a page at exact
+coordinates. It's a real differentiator: instead of Photoshopping a logo onto a
+fixed template, you actually design the document.
 
-## What this page will cover
+This page covers the field palette, the page model, positioning, and saving/sharing
+forms. The data side (binding fields to columns, tokens) is in
+[Data binding and fields](./03-data-binding-and-fields.md).
 
-- Pixel-positioned form layout for invoices, packing slips, statements, checks, labels
-- The field palette: Data, Text, Image, Line, Rect, BarCode, Table, ImgLink, Page-Number
-- Headers vs. footers vs. body
-- Page-group page numbering (`{nb1}`, `{nb2}` aliases for multi-form batch print)
-- Saving and versioning form definitions
-- Importing/exporting forms (JSON files in the `phreeform` table)
-- Using a logo: image storage path, sizing, hi-DPI considerations
+---
 
-## Why it matters
+## The field palette
 
-The form designer is a real differentiator — most cheap accounting apps
-require Photoshop-ing a logo onto a fixed template. Bizuno lets you actually
-lay out your documents.
+Each thing you place on a form is a **field** of a given type:
+
+| Type code | Field            | What it does                                              |
+|-----------|------------------|----------------------------------------------------------|
+| `Data`    | Data             | A single value bound to a SQL column (header/footer data) |
+| `Text`    | Text             | Literal text (and [tokens](./03-data-binding-and-fields.md#tokens)) |
+| `Tbl`     | Table            | A repeating block — one row per query result (the line items) |
+| `TDup`    | Table (dup)      | A second copy of a table at different coordinates          |
+| `TBlk`    | Text Block       | A multi-field single-row block                            |
+| `Ttl`     | Total            | An aggregate/total value                                  |
+| `Img`     | Image            | A static image from the images folder                    |
+| `ImgLink` | Image Link       | A data-bound image (path comes from the query)           |
+| `CImg`    | Company Logo     | Your business logo                                        |
+| `CDta` / `CBlk` | Company Data / Block | Your business name/address fields                 |
+| `Line`    | Line             | A horizontal/vertical/diagonal rule                      |
+| `Rect`    | Rectangle        | A box with optional border and/or fill                    |
+| `BarCode` | Barcode          | A 1-D barcode (C128, C39, EAN, UPC, I2of5, POSTNET)      |
+| `PgNum`   | Page Number      | The page number, with multi-form batch aliases            |
+| `LtrTpl`  | Letter Template  | A letter-body template                                    |
+
+---
+
+## The page model
+
+A form definition carries the **page setup** — page size (e.g. Letter), orientation
+(`P` portrait / `L` landscape), and the four margins (in mm) — plus default fonts
+and colors for headings, data, totals, and filters.
+
+There aren't rigid "header / body / footer" bands you draw into. Instead:
+
+- **Single-render fields** (`Data`, `Text`, `Img`, `Line`, `Rect`, company fields,
+  `PgNum`, `Ttl`) are drawn once per page at their coordinates. A field's
+  **`display`** setting controls *which* pages: `0` = every page, `1` = first page
+  only, `2` = last page only. That's how you get a remittance stub on the last page,
+  or a logo only on page one.
+- **Repeating fields** (`Tbl`) draw one row per query result and paginate
+  automatically, adding pages when the rows overflow.
+
+So "header" and "footer" are really "first/every-page single fields above/below the
+table," expressed through coordinates and the `display` rule.
+
+---
+
+## Positioning fields
+
+Every field has a position and size in millimetres:
+
+- **`abscissa`** — X (distance from the left)
+- **`ordinate`** — Y (distance from the top)
+- **`width`** / **`height`** — the field's box (0 lets images auto-size)
+
+Plus per-field appearance in its settings: `font`, `size`, `align` (L/C/R), and
+`color`. Lines carry a `linetype` (H/V/C) and `length`; rectangles carry border
+(`bshow`/`bsize`/`bcolor`) and fill (`fshow`/`fcolor`) options.
+
+---
+
+## Logos and images
+
+There are three image fields, for three situations:
+
+- **`Img`** — a fixed image you uploaded (your letterhead graphic). It references a
+  file under the Bizuno data **`images/`** folder. If the file is missing, the form
+  renders a visible red placeholder rather than failing silently.
+- **`ImgLink`** — a *data-bound* image whose path comes from the query (e.g. a
+  product photo per line). Accepts JPG/PNG.
+- **`CImg`** — your company logo specifically.
+
+> **Hi-DPI tip.** PDF scales the image into the box you define (in mm), so upload a
+> logo at 2–3× the printed size for crisp output — a 30 mm-wide logo box looks best
+> fed by an image a few hundred pixels wide, not a 30-pixel thumbnail.
+
+---
+
+## Page numbering across batched forms
+
+`PgNum` prints the page number. For **batch printing** — many invoices in one PDF —
+PhreeForm supports page-group aliases (`{nb1}`, `{nb2}`, …) so each document can show
+"Page X of Y" counting *its own* pages, not the whole batch. The aliases are
+resolved when the PDF is finalized.
+
+---
+
+## Saving, versioning, and sharing
+
+- **Save** writes the whole definition (all fields and their settings) back to
+  `common_meta` as JSON, stamping `last_update`. There's no built-in version
+  history — save is a replace — so keep a copy before a big change.
+- **Copy** a form to iterate safely: duplicate, rename, edit the copy, and leave the
+  original untouched (see [Custom forms](./05-custom-forms.md#start-from-a-built-in)).
+- **Export / import** moves a form between installs as a JSON file — see
+  [Custom forms → export/import](./05-custom-forms.md#export--import).
+
+---
 
 ## Related
 
+- [Data binding and fields](./03-data-binding-and-fields.md) — binding fields to data and tokens
+- [Processors and formatters](./04-processors-and-formatters.md) — shaping values
+- [Custom forms](./05-custom-forms.md) — copy, groups, import/export, troubleshooting
 - [Report engine overview](./01-report-engine-overview.md)
-- [Custom forms](./05-custom-forms.md)

--- a/docs/04-modules-in-depth/02-phreeform/03-data-binding-and-fields.md
+++ b/docs/04-modules-in-depth/02-phreeform/03-data-binding-and-fields.md
@@ -2,31 +2,115 @@
 title: Data Binding and Fields
 category: PhreeForm
 order: 3
-status: stub
+status: draft
 audience: [admin, developer]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Data Binding and Fields
 
-> **Status:** Stub — not yet drafted.
+The [form designer](./02-form-designer.md) feels visual, but underneath every
+report and form is a **data model**: a list of fields, each bound to a source and
+each carrying a settings hash. Understanding that model is how you debug "why is
+this value blank / wrong / unformatted." This page bridges the visual UI and the
+JSON underneath.
 
-## What this page will cover
+---
 
-- The `fieldlist` model — every field on a report/form is a row
-- Field types and their settings hash
-- Token replacement: `%date%`, `%reportname%`, `%company%` (extend via `TextReplace`'s `$xKeys`/`$xVals`)
-- Mapping a SQL column → a field on the layout
-- Multi-row data (table block) vs. single-row (header/footer block)
-- "Data" vs. "Text" fields — when each is right
+## The `fieldlist` model
 
-## Why it matters
+A definition's `fieldlist` is an array of field rows. Each row is an object with its
+position, size, and a **`settings`** hash holding everything else:
 
-Form designer feels approachable; the data-binding under it is where the
-real model lives. Doc has to bridge the visual UI and the JSON structure
-underneath so power users can debug what's happening.
+| Property            | Meaning                                                  |
+|---------------------|----------------------------------------------------------|
+| `type`              | The field type (`Data`, `Text`, `Tbl`, … — see [palette](./02-form-designer.md#the-field-palette)) |
+| `abscissa` / `ordinate` | X / Y position in mm                                  |
+| `width` / `height`  | The field box in mm                                      |
+| `settings.fieldname`| The bound SQL column (for data fields)                   |
+| `settings.text`     | The literal text (for text fields)                       |
+| `settings.processing` | The [processor](./04-processors-and-formatters.md) to apply first |
+| `settings.formatting` | The [formatter](./04-processors-and-formatters.md) to apply second |
+| `settings.font` / `size` / `align` / `color` | Appearance                     |
+| `settings.display`  | `0` every page · `1` first page · `2` last page          |
+
+For reports (tabular), the same field rows double as **columns**, carrying
+`visible`, `width`, `align`, `break`, and `total` (sum this column).
+
+---
+
+## Where the data comes from
+
+A definition also lists its **source tables** (`tables`) with their join options, and
+the SQL builder turns the field list into the `SELECT`. So binding a value onto the
+page is two steps:
+
+1. Make sure the **table** is in the definition's table list (joined correctly).
+2. Set a field's **`fieldname`** to that table's column (e.g.
+   `journal_main.invoice_num`).
+
+If a value is blank on the output, the usual cause is the field's `fieldname`
+pointing at a column that isn't in the joined tables — check the table list first.
+
+---
+
+## Data fields vs. text fields
+
+The distinction trips people up, so be deliberate:
+
+- A **Data** field (`type: Data`) is **bound to a column** (`settings.fieldname`).
+  Its value comes from the current result row. Use it for anything that varies per
+  record — the invoice number, the customer name, a total.
+- A **Text** field (`type: Text`) is **literal** (`settings.text`). It prints the
+  same words every time — labels like "Invoice", "Remit to:", boilerplate terms.
+  Text fields also run through [token replacement](#tokens).
+
+Both can carry processing and formatting, but only Data pulls from the query.
+
+---
+
+## Single-row vs. multi-row (the table block)
+
+Reports and forms mix two kinds of data:
+
+- **Single-row** fields render once — the header info (invoice #, date, bill-to),
+  the totals, the footer. These are `Data`/`Text`/`Ttl`/etc. placed at fixed
+  coordinates.
+- **Multi-row** data is the **`Tbl`** (table) field: it **repeats once per result
+  row** — the line items. Inside the table field is a `boxfield` of column
+  definitions; the engine draws a row per record and paginates when it overflows.
+
+A form is typically: single-row header fields up top, one `Tbl` for the lines in the
+middle, single-row totals/footer below (the footer on the last page via
+`display: 2`).
+
+---
+
+## Tokens
+
+**Text** fields support token substitution for common values:
+
+| Token          | Resolves to              |
+|----------------|--------------------------|
+| `%date%`       | The current date         |
+| `%reportname%` | The report/form title    |
+| `%company%`    | Your company name        |
+
+(See also the page-number aliases `{nb1}`, `{nb2}` for
+[batched forms](./02-form-designer.md#page-numbering-across-batched-forms).)
+
+### Extending tokens
+
+Token replacement runs through a single helper (`TextReplace($text, $xKeys,
+$xVals)`). Code paths that render text can pass **extra key/value pairs** via
+`$xKeys`/`$xVals`, so a custom processor or a special report class can introduce its
+own tokens beyond the three built-ins. That's the seam to add document-specific
+placeholders without changing the engine.
+
+---
 
 ## Related
 
-- [Form designer](./02-form-designer.md)
-- [Processors and formatters](./04-processors-and-formatters.md)
+- [Form designer](./02-form-designer.md) — placing these fields
+- [Processors and formatters](./04-processors-and-formatters.md) — the two transformation passes
+- [Custom forms](./05-custom-forms.md)

--- a/docs/04-modules-in-depth/02-phreeform/03-data-binding-and-fields.md
+++ b/docs/04-modules-in-depth/02-phreeform/03-data-binding-and-fields.md
@@ -2,7 +2,7 @@
 title: Data Binding and Fields
 category: PhreeForm
 order: 3
-status: draft
+status: published
 audience: [admin, developer]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/02-phreeform/04-processors-and-formatters.md
+++ b/docs/04-modules-in-depth/02-phreeform/04-processors-and-formatters.md
@@ -2,30 +2,111 @@
 title: Processors and Formatters
 category: PhreeForm
 order: 4
-status: stub
+status: draft
 audience: [admin, developer]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Processors and Formatters
 
-> **Status:** Stub — not yet drafted.
+Every value PhreeForm prints can pass through **two transformation passes** before
+it lands on the page:
 
-## What this page will cover
+1. **Processing** (`viewProcess`) — *first*. Turns a raw value into a more useful
+   one: look up a related record, compute a balance, extract a piece, convert a
+   number to words.
+2. **Formatting** (`viewFormat`) — *second*. Presents the value: as currency, a
+   date, a percentage, upper/lower case.
 
-- The two transformation passes a field value goes through: `processing` then `formatting`
-- Built-in processors: `inv_image`, `image_sku`, `fa_type`, `glTypeLbl`, `n2wrd` (num to words), `lc` (lowercase), `null0`, `j_desc`, …
-- Built-in formatters: `date`, `currency`, `number`, `percent`, `storeID`, `contactID`
-- The full registry — each module declares its own processors/formatters via `*Admin::phreeformProcessing` and `phreeformFormatting`
-- How to chain or add custom ones (see [Custom PhreeForm processor](../../06-customization/04-custom-phreeform-processor.md))
+Order matters: process, then format. A contact ID might be **processed** into the
+contact's name, then a number might be **processed** into a balance and then
+**formatted** as currency. This is the seam where you customize output without
+writing SQL gymnastics — and without forking Bizuno.
 
-## Why it matters
+---
 
-This is the seam where reports get customized without forking. Knowing the
-named processors saves users from writing SQL gymnastics to get a value
-into the right shape.
+## Where they're applied
+
+At render time, for each field, the engine runs `viewProcess(value,
+field.processing)` and then `viewFormat(result, field.formatting)`. You choose the
+processor and formatter per field in the [designer](./02-form-designer.md) from
+dropdowns; they're stored as `settings.processing` and `settings.formatting` on the
+field.
+
+Either pass is optional — leave them blank and the raw value prints as-is.
+
+---
+
+## Formatters (the presentation pass)
+
+Common built-in formatters:
+
+| Formatter    | Output                                   |
+|--------------|------------------------------------------|
+| `currency`   | Localized currency                       |
+| `number` / `precise` / `rnd0d` / `rnd2d` | Numbers at various precision |
+| `percent`    | Percentage                               |
+| `date` / `dateLong` / `datetime` | Localized dates              |
+| `n2wrd`      | Number spelled out in words (for checks) |
+| `uc` / `lc`  | Upper / lower case                       |
+| `yesBno`     | Boolean → "Yes"/blank                    |
+| `null0`      | Blank a zero                             |
+| `storeID`    | Store id → store name                    |
+| `contactID` / `contactName` | Contact id → contact info |
+| `glType` / `glTypeLbl` / `glTitle` | GL account type / label / title |
+| `j_desc`     | Journal id → its name (e.g. 12 → "Sales") |
+
+(There are more — the designer dropdown lists every formatter registered on your
+install.)
+
+---
+
+## Processors (the transformation pass)
+
+Processors are richer and **module-specific** — each module contributes the ones
+relevant to its data. A sampling:
+
+| Processor      | From module | Does                                            |
+|----------------|-------------|-------------------------------------------------|
+| `inv_image` / `image_sku` | inventory | The item's image                       |
+| `inv_shrt` / `sku_name`   | inventory | Item short description / name           |
+| `contactID` / `contactName` / `cIDEmail` | contacts | Pull a contact field |
+| `AgeCur` / `Age30` / `Age60` / `Age90` / `Age120` | phreebooks | Aging buckets |
+| `paymentRcv` / `paymentDue` / `pmtNet` | phreebooks | Payment calculations  |
+| `invBalance` / `invCOGS` / `subTotal` | phreebooks | Invoice math           |
+| `shipTrack` / `shipReq`   | shipping  | Shipping/tracking values                |
+| `n2wrd`        | bizuno      | Amount in words (checks)                         |
+
+The exact set depends on which modules are installed.
+
+---
+
+## How the registry works
+
+Processors and formatters aren't hard-coded into PhreeForm — each module **declares
+its own** and PhreeForm assembles them:
+
+- A module's `admin.php` exposes `$phreeformProcessing` and `$phreeformFormatting`
+  arrays. Each entry names the processor/formatter, a display label, a group, the
+  owning module, and the **handler function** to call.
+- At startup, the registry (`initPhreeForm()`) merges every module's arrays into the
+  PhreeForm module cache.
+- `viewProcess()` / `viewFormat()` look a name up in that cache (formatters also have
+  a core hard-coded set) and dispatch to its handler.
+
+This is why installing a module can add new processors to the dropdown, and why
+your own module can too.
+
+> **Adding your own.** A custom processor or formatter is just another entry in a
+> module's `$phreeformProcessing` / `$phreeformFormatting` array pointing at a
+> function you write — no core changes. See
+> [Custom PhreeForm processor](../../06-customization/04-custom-phreeform-processor.md)
+> for the worked example.
+
+---
 
 ## Related
 
-- [Data binding and fields](./03-data-binding-and-fields.md)
-- [Custom PhreeForm processor](../../06-customization/04-custom-phreeform-processor.md)
+- [Data binding and fields](./03-data-binding-and-fields.md) — where processing/formatting attach
+- [Custom PhreeForm processor](../../06-customization/04-custom-phreeform-processor.md) — write your own
+- [Form designer](./02-form-designer.md)

--- a/docs/04-modules-in-depth/02-phreeform/04-processors-and-formatters.md
+++ b/docs/04-modules-in-depth/02-phreeform/04-processors-and-formatters.md
@@ -2,7 +2,7 @@
 title: Processors and Formatters
 category: PhreeForm
 order: 4
-status: draft
+status: published
 audience: [admin, developer]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/02-phreeform/05-custom-forms.md
+++ b/docs/04-modules-in-depth/02-phreeform/05-custom-forms.md
@@ -2,30 +2,134 @@
 title: Custom Forms
 category: PhreeForm
 order: 5
-status: stub
+status: draft
 audience: [admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Custom Forms
 
-> **Status:** Stub — not yet drafted.
+The number-one reason people customize PhreeForm is branded documents — your logo,
+your layout, your terms on the invoice. You don't start from a blank page and you
+don't need developer skills: copy a built-in form, tweak it, save it under a new
+name. This page covers that flow, how forms attach to journals, moving forms between
+installs, and what to check if a form renders wrong after the 7.3.9 PDF change.
 
-## What this page will cover
+---
 
-- Starting from a built-in form (copy → edit → save with new name)
-- Per-customer form override (each customer can have a default form)
-- Form folders (`cust:j10` for invoices, `cust:rtn` for returns, etc.)
-- Common customizations: branded letterhead, custom line layouts, multi-language variants
-- Sharing forms across installs — export/import JSON
-- Troubleshooting a form that renders wrong post-7.3.9 (tFPDF migration considerations: HTML in cells, barcode types)
+## Start from a built-in
 
-## Why it matters
+Never edit a shipped form directly — copy it first:
 
-Branded documents are the #1 reason customers ask for a custom form. Doc has
-to walk through this without requiring developer skills.
+1. Open the form list and pick the built-in closest to what you want (e.g. the
+   stock sales invoice).
+2. **Copy** it. This duplicates the whole definition under a new title, leaving the
+   original intact (your fallback).
+3. Edit the **copy** in the [designer](./02-form-designer.md) — drop in your logo,
+   adjust columns, add terms text.
+4. Save. Your version now appears alongside the built-in for that document type.
+
+> Keep the original built-in untouched. If your custom form ever breaks, you can
+> copy the built-in again and re-apply your changes.
+
+---
+
+## Form groups
+
+Every form/report has a **`group_id`** that decides where it shows up. The format is
+`module:context`. When you print from a transaction, Bizuno offers the forms whose
+group matches that journal (via `getDefaultFormID()`):
+
+| Journal                  | Group       |
+|--------------------------|-------------|
+| Sales Quote (9)          | `cust:j9`   |
+| Sales Order (10)         | `cust:j10`  |
+| Sales / invoice (12)     | `cust:j12`  |
+| Credit Memo (13)         | `cust:j13`  |
+| Cash Receipt (18) / Vendor Refund (17) | `cust:j18` |
+| Point of Sale (19)       | `cust:j19`  |
+| RFQ (3)                  | `vend:j3`   |
+| Purchase Order (4)       | `vend:j4`   |
+| Purchase / bill (6)      | `vend:j6`   |
+| Vendor Credit (7)        | `vend:j7`   |
+| Pay Bills (20) / POP (21) / Customer Refund (22) | `bnk:j20` |
+| Assembly (14)            | `inv:j14`   |
+| Adjustment (16)          | `inv:j16`   |
+
+Plus non-journal groups for statements (`cust:stmt`, `vend:stmt`), labels
+(`cust:lblc`, `vend:lblv`), letters (`cust:ltr`, `vend:ltr`), returns (`cust:rtn`),
+work-order forms (`mfg:wo`), and reports (`gl:rpt`, `inv:rpt`, `mfg:rpt`, `hr:rpt`,
+`ship:rpt`, `misc:rpt`). **Keep a custom form in the same group as the built-in you
+copied** so it's offered in the right place.
+
+---
+
+## Choosing which form prints
+
+When a journal has more than one form in its group, you pick at print time. There is
+a **default form per document type** (the group's default), so the common case is
+one click.
+
+> **No per-customer default form.** A frequent expectation is "assign customer X
+> their own invoice template." Bizuno core does **not** have a per-customer
+> default-form override — forms default by **document type/group**, not by contact.
+> (There is a user-level *bookmark* mechanism for reports, which is a different
+> thing.) If you genuinely need per-customer templates, that's a customization, not
+> a setting — most shops instead make a multi-language or multi-brand form and
+> select it at print time.
+
+---
+
+## Multi-language and multi-brand variants
+
+Because forms are just definitions in a group, the practical pattern for "different
+look for different situations" is **multiple forms in the same group** — e.g. an
+English and a French invoice, or two brands' letterheads — and you choose the right
+one when you print. Each is a copy with its own text fields and logo.
+
+---
+
+## Export / import
+
+Forms move between installs as JSON:
+
+- **Export** a form to download its definition as a `.json` file. (Export resets its
+  access to "all users/roles" so it's portable.)
+- **Import** a `.json` file (or one of the shipped definitions in
+  `locale/<lang>/reports/`) to create the form here, optionally renaming it or
+  replacing an existing one of the same name.
+
+This is how you develop a form on one site and roll it to others.
+
+---
+
+## Troubleshooting after 7.3.9
+
+The 7.3.9 move to tFPDF (from TCPDF) is mostly invisible, but if a *custom* form
+looks off after upgrading, check these:
+
+- **HTML in a cell isn't rendering.** Only a small tag set is supported by the
+  in-tree shim: `<b>/<strong>`, `<i>/<em>`, `<u>`, `<font color="…">`, and
+  `<p>`/`<div>`/`<br>` as line breaks. Richer HTML (tables, styles, lists) won't
+  render — simplify the markup. Unsupported tags are stripped but their text is
+  kept.
+- **A barcode is blank or wrong.** Barcodes now come from
+  `picqer/php-barcode-generator`. Make sure the field's symbology is one of the
+  supported types (C128/A/B/C, C39, EAN-13/8, UPC-A/E, Interleaved 2-of-5, POSTNET)
+  and that the data is valid for that symbology (e.g. EAN-13 needs the right digit
+  count).
+- **A logo/image shows a red placeholder.** The image file isn't found under the
+  data `images/` folder — re-upload it or fix the `Img` field's file path.
+- **Fonts look different.** tFPDF uses its own font set; a font referenced by an old
+  TCPDF-era form may fall back. Re-pick a standard font on the affected fields.
+
+For deeper PDF issues, see
+[PDF rendering issues](../../09-troubleshooting/04-pdf-rendering-issues.md).
+
+---
 
 ## Related
 
-- [Form designer](./02-form-designer.md)
+- [Form designer](./02-form-designer.md) — building the layout
+- [Report engine overview](./01-report-engine-overview.md) — the 7.3.9 migration in context
 - [PDF rendering issues](../../09-troubleshooting/04-pdf-rendering-issues.md)

--- a/docs/04-modules-in-depth/02-phreeform/05-custom-forms.md
+++ b/docs/04-modules-in-depth/02-phreeform/05-custom-forms.md
@@ -2,7 +2,7 @@
 title: Custom Forms
 category: PhreeForm
 order: 5
-status: draft
+status: published
 audience: [admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/02-phreeform/README.md
+++ b/docs/04-modules-in-depth/02-phreeform/README.md
@@ -13,8 +13,8 @@ basic inline HTML in cells comes from an in-tree shim.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [Report engine overview](./01-report-engine-overview.md)              | stub   | bookkeeper, admin |
-| 02 | [Form designer](./02-form-designer.md)                                | stub   | admin          |
-| 03 | [Data binding and fields](./03-data-binding-and-fields.md)            | stub   | admin, developer |
-| 04 | [Processors and formatters](./04-processors-and-formatters.md)        | stub   | admin, developer |
-| 05 | [Custom forms](./05-custom-forms.md)                                  | stub   | admin          |
+| 01 | [Report engine overview](./01-report-engine-overview.md)              | draft  | bookkeeper, admin |
+| 02 | [Form designer](./02-form-designer.md)                                | draft  | admin          |
+| 03 | [Data binding and fields](./03-data-binding-and-fields.md)            | draft  | admin, developer |
+| 04 | [Processors and formatters](./04-processors-and-formatters.md)        | draft  | admin, developer |
+| 05 | [Custom forms](./05-custom-forms.md)                                  | draft  | admin          |

--- a/docs/04-modules-in-depth/02-phreeform/README.md
+++ b/docs/04-modules-in-depth/02-phreeform/README.md
@@ -13,8 +13,8 @@ basic inline HTML in cells comes from an in-tree shim.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [Report engine overview](./01-report-engine-overview.md)              | draft  | bookkeeper, admin |
-| 02 | [Form designer](./02-form-designer.md)                                | draft  | admin          |
-| 03 | [Data binding and fields](./03-data-binding-and-fields.md)            | draft  | admin, developer |
-| 04 | [Processors and formatters](./04-processors-and-formatters.md)        | draft  | admin, developer |
-| 05 | [Custom forms](./05-custom-forms.md)                                  | draft  | admin          |
+| 01 | [Report engine overview](./01-report-engine-overview.md)              | published | bookkeeper, admin |
+| 02 | [Form designer](./02-form-designer.md)                                | published | admin          |
+| 03 | [Data binding and fields](./03-data-binding-and-fields.md)            | published | admin, developer |
+| 04 | [Processors and formatters](./04-processors-and-formatters.md)        | published | admin, developer |
+| 05 | [Custom forms](./05-custom-forms.md)                                  | published | admin          |

--- a/docs/04-modules-in-depth/03-inventory/03-assemblies.md
+++ b/docs/04-modules-in-depth/03-inventory/03-assemblies.md
@@ -83,14 +83,32 @@ items** and drop them into the bill of materials like any other line:
 Bizuno includes these lines when it rolls up the assembly's cost
 (`dbGetInvAssyCost` sums `qty × item_cost` across **every** BOM line, regardless of
 type), so the finished item's standing cost reflects materials **plus** the labor
-and overhead you've itemized.
+and overhead you've itemized. The **build-post** capitalizes those same lines into
+the finished item's actual inventory value — so the posted cost (and the COGS when
+the assembly is later sold) matches the rolled-up estimate, not just the materials.
 
-> **One nuance to know.** Labor/charge items are non-stock, so at *build-post*
-> time (jID 14) they aren't moved through inventory/COGS accounts the way stocked
-> components are — they contribute to the item's **computed cost**, not to a
-> separate GL inventory leg. For most shops the computed cost is exactly what you
-> want on margin reports; just be aware the labor isn't capitalized as its own
-> ledger entry during the build.
+### GL treatment of labor/overhead lines
+
+Stocked components move value *between* asset accounts (component inventory → finished
+inventory), so they self-balance. A non-stock labor/charge line has no inventory layer
+to draw from, so the build needs an offsetting credit. Bizuno credits the **labor
+item's Inventory/Asset GL account** (`gl_inv`) for the line's `qty × item_cost` while
+debiting that amount into the finished-goods inventory value:
+
+| Leg | Account | Build (qty > 0) | Un-build (qty < 0) |
+|-----|---------|-----------------|--------------------|
+| Finished assembly | assembly `gl_inv` (finished inventory) | **Debit** materials + labor | **Credit** materials + labor |
+| Each stocked component | component `gl_inv` | **Credit** layer cost | **Debit** layer cost |
+| Each labor/charge line | labor `gl_inv` (clearing) | **Credit** `qty × item_cost` | **Debit** `qty × item_cost` |
+
+> **Configure the labor item's Inventory/Asset account deliberately.** Point it at a
+> **labor-applied / overhead-absorbed clearing account** (a contra to wherever the
+> actual labor/overhead expense lands), *not* a raw stock account. The build credits
+> this account to relieve the period's labor/overhead expense and rolls that cost into
+> the finished asset; it becomes COGS when the assembly sells. Labor lines are still
+> non-stock, so no `qty_stock`, inventory layer, or COGS-usage record is created for
+> them — only the balanced GL leg above. By default a labor/charge item's `gl_inv` is
+> the **non-stock** account, so set it explicitly if you want a dedicated clearing account.
 
 ---
 
@@ -98,23 +116,48 @@ and overhead you've itemized.
 
 A build is recorded by the **Assembly journal (jID 14)**. Its `Post()`:
 
-1. Reads the BOM, and for each component creates a consumption leg
+1. Reads the BOM, and for each **stocked** component creates a consumption leg
    (`gl_type='asi'`) — drawing the component's cost via its
    [costing method](./02-history-and-costing.md) (FIFO/LIFO/average) and
    **decrementing** its `qty_stock`.
-2. Creates the assembled-item leg (`gl_type='asy'`) — **incrementing** the
+2. For each **labor/charge** (non-stock) line, creates a balanced clearing leg
+   (also `gl_type='asi'`) at `qty × item_cost`, crediting the line's `gl_inv`
+   clearing account — no `qty_stock` or layer movement (see
+   [Costing labor and overhead](#costing-labor-and-overhead)).
+3. Creates the assembled-item leg (`gl_type='asy'`) — **incrementing** the
    assembly's `qty_stock` and adding a cost layer.
-3. Rolls the cost: **assembled cost = sum of the components' COGS**, and the
+4. Rolls the cost: **assembled cost = components' COGS + labor/overhead**, and the
    finished unit cost = that total ÷ quantity built.
-4. Marks the build closed.
+5. Marks the build closed.
 
-The GL effect nets within your inventory/COGS accounts — value simply moves from
-the component SKUs to the finished SKU. Reversing a build (un-post) puts the
-components back and removes the finished units.
+The GL effect nets to zero — stocked value moves from the component SKUs to the
+finished SKU, and labor/overhead moves from its clearing account into the finished
+SKU. Reversing a build (un-post) puts the components back, debits the clearing
+account back, and removes the finished units.
 
 > You don't usually post a jID 14 by hand — it's created for you when a
 > [work order](./04-work-orders-production.md) step completes. The jID 14 is the
 > accounting record; the work order is the shop-floor workflow that drives it.
+
+### Verifying labor is capitalized
+
+To confirm a labor line flows into actual cost and COGS (not just the estimate):
+
+1. Create a stocked component (e.g. `WIDGET-PART`, `item_cost` $5) and **receive 10**
+   so it has a cost layer. Create a Labor (`lb`) item *"Assembly labor"*, `item_cost`
+   $3, with its Inventory/Asset GL account set to a labor-applied clearing account.
+2. Create an assembly `ma` item *"Widget"* with BOM: 2 × `WIDGET-PART` + 5 × *Assembly
+   labor*. The cost roll-up should read **$25** (`2×5 + 5×3`).
+3. **Build 1** Widget (post the jID 14). Verify:
+   - `inventory_history` for `WIDGET`: one new layer, `unit_cost = 25` (not 10).
+   - `journal_item` rows for the build: a `gl_type='asy'` debit of $25 to the Widget's
+     `gl_inv`; an `asi` credit of $10 to the part's `gl_inv`; an `asi` credit of **$15**
+     to the labor clearing account. Debits = credits = $25.
+4. **Sell 1** Widget. The sale's COGS leg (`gl_type='cog'`) should be **$25**, including
+   the $15 labor — confirm via the GL or `dbGetCOGSj12()`.
+5. **Un-build** (post a jID 14 with qty −1, or un-post the build). Confirm the legs
+   reverse exactly: part `gl_inv` debited $10, labor clearing debited $15, Widget
+   `gl_inv` credited $25 — net zero, and the Widget layer/`qty_stock` is removed.
 
 ---
 


### PR DESCRIPTION
## What

Drafts the full **PhreeForm** module section (`04-modules-in-depth/02-phreeform/`), all five stubs → `draft`.

- **Report engine overview** — reports vs. forms, the SQL→data→process/format→render→deliver lifecycle, output formats (reports PDF/HTML/CSV; forms PDF-only), delivery channels, and the 7.3.9 tFPDF/picqer/HTML-shim migration.
- **Form designer** — the real field palette, the page/`display`-rule model, positioning, logos, batched page numbering, save/copy/export.
- **Data binding and fields** — the `fieldlist` + `settings` model, Data vs. Text fields, single-row vs. `Tbl` multi-row, table sources/joins, and tokens (+ the `TextReplace` extension seam).
- **Processors and formatters** — the two passes (process then format), built-in tables, and the per-module registry that makes them extensible.
- **Custom forms** — copy-a-builtin flow, the `group_id` model + `getDefaultFormID` journal map, export/import, and post-7.3.9 troubleshooting.

## Corrections to stub assumptions (verified against code)
- Definitions are stored in **`common_meta`** (key `phreeform`) + a `phreeform_cache` index — **not** a separate `phreeform` table.
- **No per-customer default-form override** — forms default by document type/group; `bookmarks_phreeform` is a user-level bookmark, a different feature.

## Provenance
Grounded in `controllers/phreeform/*`, `view/main.php` (`viewProcess`/`viewFormat`), `model/registry.php`+`functions.php`, and `install/phreeform.php`.

## Status
Pages are `status: draft` — not synced to bizuno.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)