### PR TITLE
docs(shipping): Shipping module section

### DIFF
--- a/docs/04-modules-in-depth/06-shipping/01-carriers.md
+++ b/docs/04-modules-in-depth/06-shipping/01-carriers.md
@@ -2,29 +2,112 @@
 title: Carriers
 category: Shipping
 order: 1
-status: stub
+status: draft
 audience: [admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Carriers
 
-> **Status:** Stub — not yet drafted.
+The Shipping module rates, buys, and prints labels through real carrier APIs, plus a
+set of rule-based "carriers" for when you don't need a live integration. The setup
+screens are credential-heavy and look intimidating; this page de-mystifies what each
+carrier needs and how the pieces fit.
 
-## What this page will cover
+---
 
-- Supported carriers: USPS, UPS, FedEx — what each requires (API key, account number, OAuth flow)
-- Carrier credentials setup
-- Address validation (which carriers offer it, when it runs)
-- Rate-shopping across carriers from a single shipment
-- Pickup scheduling (where supported)
-- Per-store vs. per-business carrier configuration
+## What's actually integrated
 
-## Why it matters
+Bizuno ships more than the headline three. Two tiers:
 
-Carrier integrations are credential-laden and the setup screens look
-intimidating. Doc should de-mystify each.
+**Live API carriers** (real rating, label purchase, tracking):
+
+| Carrier      | Notes                                                       |
+|--------------|------------------------------------------------------------|
+| UPS          | REST API; account must be certified before live labels     |
+| USPS         | OAuth API (developer.usps.com) with an EPS payment account  |
+| FedEx        | REST API; optional separate Freight (LTL) account          |
+| Endicia      | USPS postage via Stamps.com/Endicia; buy/refund postage     |
+| Canada Post  | SOAP API; domestic + international rating                   |
+| XPO, ODFL    | LTL freight carriers                                        |
+
+**Rule-based methods** (no API — you set the math):
+
+`Flat Rate`, `Free Shipper`, `Percent` (of order), `Item` (per-item formula),
+`Best Way` (manual rate entry), and `Third Party` (bill a third-party account).
+Use these for simple or negotiated shipping without wiring up a carrier API.
+
+---
+
+## Credentials
+
+Carrier credentials are entered per carrier in its settings and stored **per
+business** (globally), in the carrier-methods configuration — **not** per store. The
+key fields by carrier:
+
+| Carrier      | Required credentials                                                |
+|--------------|--------------------------------------------------------------------|
+| UPS          | account number, REST API key, REST secret, test/prod toggle        |
+| USPS         | client ID + client secret (OAuth), EPS payment account, CRID, MID, price type |
+| FedEx        | account number, REST API key, REST secret, (optional) Freight account |
+| Endicia      | client key                                                         |
+| Canada Post  | customer number, test user/pass, production user/pass              |
+
+> **Test mode first.** Each live carrier has a test/sandbox toggle. Configure and
+> validate in test mode, confirm you can rate and produce a label, then flip to
+> production. UPS in particular requires **certification** with the carrier before
+> production labels work.
+
+---
+
+## Per-store usage
+
+Although credentials are global, an individual shipment chooses **which store's
+addresses** to use — the ship-from (pickup) store and the bill-to store — so a
+multi-store business ships from the right origin while sharing one set of carrier
+API keys.
+
+---
+
+## Address validation
+
+UPS, USPS, FedEx, and Endicia offer **address validation**; it runs when you check
+**Verify Address** on the label form, and can correct the address before you buy the
+label. (Canada Post's validation is not currently working — treat it as
+rating/labeling only.)
+
+---
+
+## Rate shopping
+
+You can **compare rates across carriers** for one shipment: select the carriers to
+quote, and Bizuno calls each one's rate API and shows the results in a table you pick
+from. There's also a programmatic rate path that quotes all default-enabled carriers
+at once. This is the fastest way to land on the cheapest viable service per package.
+
+---
+
+## Pickup scheduling
+
+Pickup handling is **partial**: the label form carries a pickup-type field (daily
+pickup, on-call, drop-box, counter, etc.) that's sent **with the shipment**, but
+Bizuno does not make a separate "schedule a pickup" API call or manage a pickup
+calendar. Treat it as "tell the carrier how this package is tendered," not a pickup
+scheduler.
+
+---
+
+## Invoice reconciliation
+
+The Shipping module can **reconcile a carrier invoice** against what you booked —
+currently implemented for **FedEx**: upload the FedEx invoice summary (CSV) and
+Bizuno matches it to your shipping log, flags over-charges and mismatches, and writes
+a reconciliation report. Other carriers expose **bulk tracking** but not invoice
+reconciliation. See [Label printing → reconciliation](./02-label-printing.md#reconciliation-and-end-of-day).
+
+---
 
 ## Related
 
 - [Label printing](./02-label-printing.md)
+- [Zebra Browser Print](./03-zebra-browser-print.md)

--- a/docs/04-modules-in-depth/06-shipping/01-carriers.md
+++ b/docs/04-modules-in-depth/06-shipping/01-carriers.md
@@ -2,7 +2,7 @@
 title: Carriers
 category: Shipping
 order: 1
-status: draft
+status: published
 audience: [admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/06-shipping/02-label-printing.md
+++ b/docs/04-modules-in-depth/06-shipping/02-label-printing.md
@@ -2,7 +2,7 @@
 title: Label Printing
 category: Shipping
 order: 2
-status: draft
+status: published
 audience: [bookkeeper, admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/06-shipping/02-label-printing.md
+++ b/docs/04-modules-in-depth/06-shipping/02-label-printing.md
@@ -2,31 +2,109 @@
 title: Label Printing
 category: Shipping
 order: 2
-status: stub
+status: draft
 audience: [bookkeeper, admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Label Printing
 
-> **Status:** Stub — not yet drafted.
+If you ship 50 times a day, the label path is where seconds add up. This page covers
+the lifecycle from rate to printed label, the two print paths (plain-paper PDF vs.
+direct-to-Zebra thermal), and the realities of voiding, reconciliation, and
+international.
 
-## What this page will cover
+---
 
-- The shipping label lifecycle: rate → buy → print → manifest
-- Browser-based printing (PDF) vs. direct-to-Zebra (ZPL via Browser Print)
-- Label size formats (4×6, 4×8, 8.5×11 letter)
-- Re-printing a label (voiding the original where carriers require it)
-- Batch label printing for end-of-day shipping
-- Customs forms for international shipping
+## The lifecycle
 
-## Why it matters
+```
+   rate  ──►  buy label  ──►  label saved + logged  ──►  print  ──►  reconcile
+ (compare    (carrier API     (file on disk +         (PDF or      (match the
+  carriers)   returns label)   shipping_log row)       thermal)     carrier invoice)
+```
 
-The label-print path is where shipping speed matters most — every extra
-click or driver problem costs real time. Doc should optimize for "I do this
-50 times a day."
+1. **Rate** the package (optionally [across carriers](./01-carriers.md#rate-shopping)).
+2. **Buy** the label — Bizuno calls the carrier's label API, which returns the label
+   (and tracking number).
+3. Bizuno **saves the label file** under
+   `data/shipping/labels/<carrier>/<year>/<month>/<day>/<tracking>.<ext>` and writes a
+   **shipping-log** entry (tracking, service, booked vs. net cost, ship/delivery
+   dates).
+4. **Print** it (below).
+5. Later, **reconcile** the carrier's invoice against what you booked.
+
+### Buying postage
+
+How you fund labels depends on the carrier:
+
+- **Endicia** — buy postage into the account from inside Bizuno (and refund).
+- **USPS** — funded through your EPS payment account at usps.com (not inside Bizuno).
+- **UPS / FedEx** — no prepaid balance; each label charges your carrier account.
+
+---
+
+## Two print paths
+
+A bought label exists as a file, and its **extension** decides how you print it:
+
+| File   | Path                  | How it prints                                            |
+|--------|-----------------------|---------------------------------------------------------|
+| `.pdf` | plain-paper           | "Download/Print PDF" → print on any printer             |
+| `.lpt` | thermal (ZPL/EPL)     | "Print Thermal" → sent straight to a Zebra label printer via [Browser Print](./03-zebra-browser-print.md) |
+| `.gif` | image                 | shown in a popup to print                               |
+
+The label view shows whichever buttons match the files that exist — if both a PDF and
+a thermal file are present, you choose. Which format the carrier returns is driven by
+the carrier's **printer-type / label-format** setting (`label_pdf` / `label_thermal`).
+
+### Label sizes
+
+The standard thermal label is **4×6**. Carriers expose their own size/stock codes
+(e.g. FedEx and Canada Post offer doc-tab and letter half-page variants); set the
+format in the carrier's settings. USPS labels are produced at 4×6.
+
+---
+
+## Reprint and void
+
+- **Reprint** — the label file is on disk, so you can re-open the shipment and print
+  it again without re-buying.
+- **Void / refund** — supported for **UPS, USPS, FedEx, and Endicia** via the
+  carrier's label-delete API. USPS, for example, reports back whether the label was
+  *canceled* (never charged) or *disputed* (refund queued). Voiding removes the local
+  label file and log entry. Mind each carrier's same-day/void-window rules.
+
+---
+
+## Reconciliation and end-of-day
+
+- **FedEx invoice reconciliation** — upload the FedEx invoice summary CSV; Bizuno
+  matches it to your shipping log and flags discrepancies, writing a report you can
+  review. (See [Carriers → invoice reconciliation](./01-carriers.md#invoice-reconciliation).)
+- **Bulk tracking** — USPS and UPS can refresh tracking status for many shipments at
+  once.
+
+> **What it doesn't do.** There's no carrier **end-of-day manifest / SCAN-form
+> generation** built in — the workflow is buy-and-print per shipment, with the label
+> files retained and the FedEx CSV reconciliation after the fact. If your operation
+> depends on a daily close manifest, plan around that gap.
+
+---
+
+## International
+
+International **rating** works (Canada Post and USPS carry full international service
+codes; UPS/FedEx international services rate too). However, **customs-declaration form
+generation is not implemented** — the customs payload is stubbed in code, not wired to
+the form. For international shipments you'll rate and label, but produce customs
+paperwork through the carrier's own portal. Don't promise CN22/CP72/commercial-invoice
+generation from Bizuno today.
+
+---
 
 ## Related
 
 - [Carriers](./01-carriers.md)
-- [Zebra Browser Print](./03-zebra-browser-print.md)
+- [Zebra Browser Print](./03-zebra-browser-print.md) — the thermal path
+- [PDF rendering issues](../../09-troubleshooting/04-pdf-rendering-issues.md)

--- a/docs/04-modules-in-depth/06-shipping/03-zebra-browser-print.md
+++ b/docs/04-modules-in-depth/06-shipping/03-zebra-browser-print.md
@@ -2,7 +2,7 @@
 title: Zebra Browser Print
 category: Shipping
 order: 3
-status: draft
+status: published
 audience: [admin]
 last-updated: 2026-06-07
 ---

--- a/docs/04-modules-in-depth/06-shipping/03-zebra-browser-print.md
+++ b/docs/04-modules-in-depth/06-shipping/03-zebra-browser-print.md
@@ -2,30 +2,109 @@
 title: Zebra Browser Print
 category: Shipping
 order: 3
-status: stub
+status: draft
 audience: [admin]
-last-updated: 2026-05-15
+last-updated: 2026-06-07
 ---
 
 # Zebra Browser Print
 
-> **Status:** Stub — not yet drafted.
+This is the bridge that lets a **web app print to a local Zebra label printer** — and
+it's one of the most support-heavy setup paths in Bizuno. Get it right once per
+workstation and thermal labels print in a click; get it wrong and you'll chase "no
+printer found" all day. This page walks the setup and the failure modes.
 
-## What this page will cover
+---
 
-- What Zebra Browser Print is — a small local app from Zebra that proxies the browser to the local Zebra printer over `https://127.0.0.1:9100`
-- Per-OS install: Windows, macOS, Linux
-- The Chrome trust-the-cert step (the screen most users get stuck on)
-- Pairing the printer with the running app
-- Common failure modes: printer not turned on, "no printer found" with the wrong device filter, secure-connection refused
-- Testing the bridge from the browser console
-- When to use it vs. the basic PDF-print path
+## What it is
 
-## Why it matters
+Zebra **Browser Print** is a small desktop application (from Zebra) that runs on the
+shipping workstation and exposes the local printer to the browser over a localhost
+service. Bizuno's web page talks to that service, which relays the label data to the
+USB/network Zebra printer.
 
-This is one of the most support-ticket-heavy setup paths in Bizuno. A good
-doc page with screenshots cuts the support load in half.
+```
+  Bizuno web page ──HTTP──► Zebra Browser Print service ──► Zebra printer
+   (labelThermal)          (localhost 127.0.0.1:9100)        (USB / network)
+```
+
+- The service listens on **`http://127.0.0.1:9100`** (and **`https://127.0.0.1:9101`**
+  for Safari / secure-context cases).
+- The browser loads Zebra's **BrowserPrint SDK** JavaScript, which Bizuno injects on
+  the shipping page.
+
+> **The SDK is not bundled.** Bizuno expects the Zebra `BrowserPrint-3.x.x.min.js`
+> file to be present (downloaded from Zebra's support site) — it is not redistributed
+> in the repo. If thermal printing says "Browser Print is not loaded," the SDK file is
+> the first thing to check.
+
+---
+
+## Per-workstation setup
+
+Browser Print is installed **on each PC that prints labels**, not on the server:
+
+1. **Install Zebra Browser Print** for the workstation OS (Windows / macOS / Linux)
+   from Zebra.
+2. **Connect and power on** the Zebra printer (USB or network) and confirm the OS
+   sees it.
+3. **Register the printer** in the Browser Print app so the service reports it.
+4. If the browser uses the **HTTPS** endpoint (`:9101`), you may have to **trust the
+   local certificate** once — visit `https://127.0.0.1:9101/available` and accept the
+   certificate so the browser will talk to the service. (The default
+   `http://127.0.0.1:9100` path avoids this, but mixed-content/secure-context rules in
+   some browsers push you to HTTPS.)
+
+---
+
+## How printing works
+
+When you click **Print Thermal** on a bought label:
+
+1. Bizuno reads the thermal label file(s) — raw **ZPL/EPL** returned by the carrier
+   and stored as `.lpt` — and hands them to the page's `labelThermal()` routine.
+2. The SDK's device discovery (`getLocalDevices()`) returns the registered devices;
+   Bizuno uses the **first printer** reported.
+3. Each label is sent to that printer via the device's `send()` method. Multiple
+   labels from one shipment are sent in sequence on a single click.
+
+There's no printer-picker UI — it prints to the first Zebra device the service
+reports. If you have several, the first registered one wins.
+
+---
+
+## When it fails — and how to tell
+
+The thermal routine surfaces specific alerts; match the message to the fix:
+
+| Symptom / message                          | Cause & fix                                              |
+|--------------------------------------------|---------------------------------------------------------|
+| "Browser Print is not loaded"              | The Zebra SDK JS isn't present/loaded — reload; confirm the SDK file is installed |
+| "No printer found" (with a device list)    | Printer not registered/powered, or reported under a different category — open Browser Print, register the device, check power/USB |
+| "Could not reach Zebra Browser Print"      | The service isn't running or localhost is blocked — start the app; load `https://127.0.0.1:9101/available` to confirm; check firewall/AV on localhost |
+| "Print failed on \<printer\>"              | The job reached the printer but errored — check media/ribbon, printer status |
+
+**Quick bridge test:** browse to **`https://127.0.0.1:9101/available`** (or the
+`:9100` HTTP equivalent). If it returns device JSON, the service and printer are
+reachable and the problem is elsewhere; if it doesn't load, the service/cert/firewall
+is the issue.
+
+---
+
+## When to use it vs. plain PDF
+
+- **Use Browser Print (thermal)** when you print volume on a dedicated 4×6 Zebra — it
+  prints a ZPL label directly, no PDF dialog, no scaling surprises.
+- **Use the PDF path** for occasional shipping or when you print labels on a regular
+  laser/inkjet — the carrier returns a `.pdf` you print like any document, with no
+  desktop app to install. See [Label printing → two print paths](./02-label-printing.md#two-print-paths).
+
+If a workstation only ever prints to a laser printer, you don't need Browser Print at
+all — stick with PDF labels.
+
+---
 
 ## Related
 
 - [Label printing](./02-label-printing.md)
+- [Carriers](./01-carriers.md)

--- a/docs/04-modules-in-depth/06-shipping/README.md
+++ b/docs/04-modules-in-depth/06-shipping/README.md
@@ -8,6 +8,6 @@ from a web app.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [Carriers](./01-carriers.md)                                          | stub   | admin          |
-| 02 | [Label printing](./02-label-printing.md)                              | stub   | bookkeeper, admin |
-| 03 | [Zebra Browser Print](./03-zebra-browser-print.md)                    | stub   | admin          |
+| 01 | [Carriers](./01-carriers.md)                                          | draft  | admin          |
+| 02 | [Label printing](./02-label-printing.md)                              | draft  | bookkeeper, admin |
+| 03 | [Zebra Browser Print](./03-zebra-browser-print.md)                    | draft  | admin          |

--- a/docs/04-modules-in-depth/06-shipping/README.md
+++ b/docs/04-modules-in-depth/06-shipping/README.md
@@ -8,6 +8,6 @@ from a web app.
 
 | #  | Page                                                                  | Status | Audience       |
 |----|-----------------------------------------------------------------------|--------|----------------|
-| 01 | [Carriers](./01-carriers.md)                                          | draft  | admin          |
-| 02 | [Label printing](./02-label-printing.md)                              | draft  | bookkeeper, admin |
-| 03 | [Zebra Browser Print](./03-zebra-browser-print.md)                    | draft  | admin          |
+| 01 | [Carriers](./01-carriers.md)                                          | published | admin          |
+| 02 | [Label printing](./02-label-printing.md)                              | published | bookkeeper, admin |
+| 03 | [Zebra Browser Print](./03-zebra-browser-print.md)                    | published | admin          |


### PR DESCRIPTION
## What
Drafts the full **Shipping** module section (`04-modules-in-depth/06-shipping/`), all three stubs → `draft`. This completes all six **Modules in Depth** sections.

- **Carriers** — the real integrated set (UPS/USPS/FedEx/Endicia/Canada Post + XPO/ODFL LTL) and rule-based methods; per-carrier credentials; global config with per-shipment store addresses; address validation; multi-carrier rate shopping; pickup handling; FedEx invoice reconciliation.
- **Label printing** — the rate→buy→save/log→print→reconcile lifecycle, postage funding, the two print paths (PDF vs. `.lpt` thermal ZPL), sizing, reprint/void, bulk tracking.
- **Zebra Browser Print** — the localhost bridge (`http://127.0.0.1:9100` / `https://…:9101`), per-workstation install, cert trust, the print flow, the failure-mode table + `/available` test, and PDF-vs-thermal guidance.

## Corrections to stub assumptions (verified against code)
- More carriers than the headline three (Endicia, Canada Post, LTL freight).
- **Customs-form generation is not implemented** — international *rating* works; the customs payload is stubbed.
- **No built-in end-of-day manifest/SCAN form** — buy-and-print + FedEx CSV reconciliation only.
- Browser Print defaults to **`http://127.0.0.1:9100`** (HTTPS `:9101` on Safari), and the **Zebra SDK JS is not bundled** (downloaded from Zebra).

## Provenance
`controllers/shipping/*` (ship.php, rate.php, reconcile.php, carriers/*) and `scripts/zebra-browser-print/`.

## Status
Pages are `status: draft` — not synced to bizuno.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)