### PR TITLE
Fix blank info popup when WooCommerce REST message is an empty string

### DIFF
--- a/src/controllers/api/funnels/ifWooCommerce/ifWooCommerce.php
+++ b/src/controllers/api/funnels/ifWooCommerce/ifWooCommerce.php
@@ -443,8 +443,12 @@ function productUpload(rID) {
         $resp = $io->restRequest($args['type'], $this->settings['rest_url'], "wp-json/bizuno-api/v1/{$args['endpoint']}", ['data'=>$args['data']]);
         msgDebug("\napiAction received back from REST: ".print_r($resp, true));
         if (isset($resp['message'])) {
-            if (is_string($resp['message'])) { msgAdd($resp['message'], 'info'); } // probably an error
-            else                             { msgMerge($resp['message']); }
+            if (is_string($resp['message'])) {
+                // Skip empty/whitespace-only strings. The WC product/refresh endpoint can
+                // return a blank message per batch, which fired msgAdd('','info') => a blank
+                // info popup for every batch during a quick stock/price refresh.
+                if (trim($resp['message']) !== '') { msgAdd($resp['message'], 'info'); } // non-blank = probably an error worth surfacing
+            } else                               { msgMerge($resp['message']); }
         }
         return $resp;
     }


### PR DESCRIPTION
### Summary
On a WooCommerce **Quick refresh of pricing and stock levels**, the operator gets a flood of empty info dialogs — one blank popup per batch as it processes.

### Root cause
`src/controllers/api/funnels/ifWooCommerce/ifWooCommerce.php`, `apiAction()`:

```php
if (isset($resp['message'])) {
    if (is_string($resp['message'])) { msgAdd($resp['message'], 'info'); } // probably an error
    else                             { msgMerge($resp['message']); }
}
```

`is_string('')` is `true`, so when the `product/refresh` endpoint returns an **empty** `message` string, this fires `msgAdd('', 'info')` → a blank info dialog. `apiAction()` runs once per batch during `invRefreshNext()`, so a refresh over many SKUs produces a blank popup for every batch.

### Fix
Only surface the string when it's non-blank. Structured `message` arrays still go through `msgMerge`, and any real (non-empty) message is unaffected.

```php
if (isset($resp['message'])) {
    if (is_string($resp['message'])) {
        if (trim($resp['message']) !== '') { msgAdd($resp['message'], 'info'); }
    } else                               { msgMerge($resp['message']); }
}
```

### Environment
- Bizuno: current `main`
- PHP 8.2, MariaDB 10.5+
- WooCommerce bridge (bizuno-api) 7.4.2

### Repro
1. Tag several SKUs to sync to the store.
2. Inventory → WooCommerce → **Quick refresh of pricing and stock levels**.
3. Observe a blank info dialog appear for each batch as it processes.