### PR TITLE
Fix sizeof(null) TypeError on PHP 8 during inventory + contact merge

### DIFF
--- a/src/controllers/contacts/tools.php
+++ b/src/controllers/contacts/tools.php
@@ -162,7 +162,7 @@ class contactsTools
         $this->mergeMetaTax('tax_rate_c', 'taxAuths');
         $this->mergeMetaTax('tax_rate_v', 'taxAuths');
         $metaT = dbMetaGet('%', 'training'); // common_meta:training
-        msgDebug("\nRead ".sizeof($metaT)." rows from key training.");
+        msgDebug("\nRead ".(is_array($metaT) ? sizeof($metaT) : 0)." rows from key training.");
         if (!empty($metaT)) {
             foreach($metaT as $meta) {
                 $found = false;
@@ -182,7 +182,7 @@ class contactsTools
     private function mergeMetaTax($key, $index)
     {
         $taxC = dbMetaGet('%', $key);
-        msgDebug("\nRead ".sizeof($taxC)." rows from key $key.");
+        msgDebug("\nRead ".(is_array($taxC) ? sizeof($taxC) : 0)." rows from key $key.");
         if (empty($taxC)) { return; }
         foreach($taxC as $rate) {
             if (isset($rate[$index]) && is_array($rate[$index]) && empty($rate[$index]['rows'])) { // make new format

--- a/src/controllers/inventory/tools.php
+++ b/src/controllers/inventory/tools.php
@@ -93,7 +93,7 @@ class inventoryTools
         msgDebug("\nDeleting meta from source SKU: $srcSKU");
         $jMeta  = dbMetaGet(0, '%', 'inventory', $srcID);
         dbGetResult("DELETE FROM ".BIZUNO_DB_PREFIX."inventory_meta WHERE ref_id=$srcID");
-        msgAdd("Table inventory_meta number of source meta entries removed = ".sizeof($jMeta), 'info');
+        msgAdd("Table inventory_meta number of source meta entries removed = ".(is_array($jMeta) ? sizeof($jMeta) : 0), 'info');
         // Move the main image if not existing at dest
         $srcImg = dbGetValue(BIZUNO_DB_PREFIX.'inventory', 'image_with_path', "id=$srcID");
         $destImg= dbGetValue(BIZUNO_DB_PREFIX.'inventory', 'image_with_path', "id=$destID");
@@ -135,6 +135,7 @@ class inventoryTools
     private function renameMetaReturn($srcSKU='', $destSKU='')
     {
         $rows= dbMetaGet(0, 'return', 'journal', '%');
+        if (!is_array($rows)) { $rows = []; }
         msgDebug("\nWorking on journal_meta:return key , read ".sizeof($rows)." rows to process.");
         $cnt = 0;
         foreach ($rows as $row) {


### PR DESCRIPTION
## Problem
`inventoryTools::mergeSave()` and `contactsTools::mergeChangeCID()/mergeMetaTax()` pass `dbMetaGet()` results straight to `sizeof()`. `dbMetaGet()` returns **`null`** (not `[]`) when no rows match, and PHP 8 makes `sizeof(null)` a fatal **`TypeError`** — so a merge throws mid-operation whenever the source has no matching meta (the common case).

- `controllers/inventory/tools.php:96` — `sizeof($jMeta)`; `$jMeta = dbMetaGet(0,'%','inventory',$srcID)` is null when the source SKU has no `inventory_meta`
- `controllers/inventory/tools.php` `renameMetaReturn()` — `$rows = dbMetaGet(0,'return','journal','%')` is null when no journal return-meta exists; the `foreach` right after also TypeErrors on null
- `controllers/contacts/tools.php:165` — `sizeof($metaT)`; `dbMetaGet('%','training')`
- `controllers/contacts/tools.php:185` — `sizeof($taxC)`; `dbMetaGet('%',$key)`

## Repro
On PHP 8, merge two inventory items (or two contacts) where the loser has no `inventory_meta` / no journal return-meta:
`sizeof(): Argument #1 ($value) must be of type Countable|array, null given`

## Fix
Null-coerce at the call sites — `(is_array($x) ? sizeof($x) : 0)` — and coerce `$rows` to `[]` before the `sizeof`+`foreach` in `renameMetaReturn`. Surgical; identical behavior when the meta exists.

The deeper root cause is `dbMetaGet()` returning `null` instead of `[]`; guarding the consumers is the minimal, low-risk fix. (Found running automated merges on PHP 8.2.)
