### PR TITLE
Fix GROUP BY ... DESC removed in MySQL 8 (inventory annual history)

### DIFF
--- a/src/controllers/inventory/history.php
+++ b/src/controllers/inventory/history.php
@@ -202,7 +202,7 @@ class inventoryHistory
         // For yearly
         $stmt  = dbGetResult("SELECT DATE_FORMAT(m.post_date, '%Y') AS 'year', SUM(ABS(i.qty)) AS 'qty', SUM(i.credit_amount + i.debit_amount) AS 'total'
             FROM ".BIZUNO_DB_PREFIX."journal_main m JOIN ".BIZUNO_DB_PREFIX."journal_item i ON m.id=i.ref_id WHERE sku='".addslashes($sku)."' AND ((m.journal_id=12 AND i.gl_type='itm') OR (m.journal_id=14 AND i.gl_type='asi'))
-            GROUP BY DATE_FORMAT(m.post_date, '%Y') DESC");
+            GROUP BY DATE_FORMAT(m.post_date, '%Y') ORDER BY DATE_FORMAT(m.post_date, '%Y') DESC");
         // Get the data
         $rows  = $stmt ? $stmt->fetchAll(\PDO::FETCH_ASSOC) : [];
         return $rows;


### PR DESCRIPTION
## Problem
`inventoryHistory::annualHistory()` uses `GROUP BY DATE_FORMAT(m.post_date, '%Y') DESC`. Sort direction (`ASC`/`DESC`) on a `GROUP BY` column was **deprecated in MySQL 5.7 and removed in MySQL 8.0 / MariaDB 10.5+**. On those servers, viewing an item's annual sales history fatals:

```
SQLSTATE[42000]: Syntax error or access violation ... near 'DESC'
```

## Fix
Split the clause into a plain `GROUP BY` plus an explicit `ORDER BY DATE_FORMAT(m.post_date, '%Y') DESC` — the standards-compliant equivalent that runs on MySQL 5.x/8.x and MariaDB alike. Same result set + ordering.

Affects any install on MySQL 8 / MariaDB 10.5+ (most current managed hosting — e.g. SiteGround MariaDB 10.5+, where this surfaced).
