### PR TITLE
Fix undefined contactsPromos::managerSettings() fatal on Contacts -> Promotions

### DIFF
--- a/src/controllers/contacts/promos.php
+++ b/src/controllers/contacts/promos.php
@@ -46,6 +46,18 @@ class contactsPromos extends mgrJournal
     }
 
     /**
+     * Sets the manager grid defaults. Relies on the base defaults from
+     * mgrJournal::managerDefaults(), like the sibling contacts controllers.
+     * Without this method the constructor's $this->managerSettings() call
+     * fatals (Call to undefined method bizuno\contactsPromos::managerSettings()),
+     * breaking Contacts -> Promotions on every install.
+     */
+    protected function managerSettings()
+    {
+        parent::managerDefaults();
+    }
+
+    /**
      * Sets the page fields with their structure
      * @return array - page structure
      */


### PR DESCRIPTION
## Problem
`contactsPromos::__construct()` calls `$this->managerSettings()`, but neither `contactsPromos` nor its parent `mgrJournal` defines that method — so opening **Contacts → Promotions** (`contacts/promos/manager`) fatals on every install:

```
Call to undefined method bizuno\contactsPromos::managerSettings()
```

Every sibling contacts controller (`address.php`, `main.php`, `projects.php`) defines its own `managerSettings()`; `promos.php` is the only one missing it.

## Fix
Add the minimal `managerSettings()` that calls `parent::managerDefaults()` — the same first step every sibling uses. `managerDefaults()` already populates a complete defaults array (`rows`/`page`/`sort`/`order`/`search`), so this restores the Promotions manager without presuming promo-specific filters (those can be layered on later the way the siblings do).

## Repro
Open **Contacts → Promotions** on current `main` (PHP 8).
