### PR TITLE
Raise side-menu depth cap to 3 levels (sidemenuStruc)

### DIFF
--- a/src/view/easyUI/html5.php
+++ b/src/view/easyUI/html5.php
@@ -566,7 +566,7 @@ final class html5 {
             $state = $curSec==$idx?'open':'closed';
             $event = !empty($branch['route']) ? $branch['route'] : '';
             $action= !empty($branch['action'])? $branch['action']: '';
-            if (empty($branch['child']) || $level>1) { // limit the menu to 2 levels
+            if (empty($branch['child']) || $level>2) { // limit the menu to 3 levels
                 $tree[] = ['text'=>$text, 'iconCls'=>$this->htmlIcon($branch['icon']), 'size'=>'large', 'state'=>$state, 'action'=>$action, 'route'=>$event];
             } else {
                 $branch['child'] = sortOrder($branch['child']);

--- a/src/view/kendoUI/html5.php
+++ b/src/view/kendoUI/html5.php
@@ -555,7 +555,7 @@ final class html5 {
             $state = $curSec==$idx?'open':'closed';
             $event = !empty($branch['route']) ? $branch['route'] : '';
             $action= !empty($branch['action'])? $branch['action']: '';
-            if (empty($branch['child']) || $level>1) { // limit the menu to 2 levels
+            if (empty($branch['child']) || $level>2) { // limit the menu to 3 levels
                 $tree[] = ['text'=>$text, 'iconCls'=>$this->htmlIcon($branch['icon']), 'size'=>'large', 'state'=>$state, 'action'=>$action, 'route'=>$event];
             } else {
                 $branch['child'] = sortOrder($branch['child']);


### PR DESCRIPTION
### Problem

`sidemenuStruc()` (in both `src/view/easyUI/html5.php` and `src/view/kendoUI/html5.php`) caps the vertical side menu at **2 levels**:

```php
if (empty($branch['child']) || $level>1) { // limit the menu to 2 levels
```

For any menu structure nested 3 deep, the level-2 **parent** nodes get emitted as route-less leaves — selecting one dead-ends and falls back to the dashboard — and the level-3 children are dropped from the tree entirely. (Items that happen to sit at level 2 still work, which makes it easy to miss.)

### Why it's safe to lift

The side menu is rendered by the `easyui-sidemenu` widget, which builds an easyui **tree** (`tt.tree({data})`). The tree renders arbitrary depth, and the widget's `onBeforeSelect` already does:

```js
onBeforeSelect: function(node){ if (node.children) { return false; } }
```

so parent nodes only expand/collapse and only **leaf** nodes navigate. The 2-level limit is purely this PHP cap, not a widget limitation.

### Change

Raise the cap to 3 levels in both themes (`$level>1` → `$level>2`). This lets a module group many sub-tools under a category node (e.g. grouping a long flat `Tools` menu into a few labelled sub-groups) without losing navigation on the items underneath.

Happy to instead **remove the cap entirely** (render to the menu's defined depth) if you'd prefer that over a fixed number — the tree widget supports it either way. Just say the word and I'll update the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
