### PR TITLE
Auto-attach CSRF token to native form POSTs and fetch()

### DIFF
--- a/src/view/easyUI/common.js
+++ b/src/view/easyUI/common.js
@@ -79,6 +79,54 @@ jqBiz.ajaxSetup({ // Set defaults for ajax requests
     }
 });
 
+// CSRF Layer 2 (forms + fetch) — the ajaxSetup hook above covers every jqBiz.ajax
+// call, but native <form> POSTs and raw fetch() bypass jQuery and never get the token.
+// Attach the same per-session bizCSRF token to those too — SAME-ORIGIN ONLY — so
+// hand-built forms and fetch() callers are covered automatically, with no per-form
+// _csrf field or per-call header needed. Without this, any non-ajax POST is rejected
+// by validateCsrf() under BIZUNO_CSRF_ENFORCE and bounced to the portal home.
+(function () {
+    function bizCsrfToken() { return (typeof bizCSRF !== 'undefined' && bizCSRF) ? bizCSRF : ''; }
+    function bizCsrfSameOrigin(url) {
+        try { return new URL(url, window.location.href).origin === window.location.origin; }
+        catch (e) { return true; } // relative URL resolves to same origin
+    }
+    function bizCsrfInjectForm(form) {
+        if (!form || form.tagName !== 'FORM') { return; }
+        if ((form.method || 'get').toLowerCase() !== 'post') { return; }
+        if (!bizCsrfSameOrigin(form.getAttribute('action') || window.location.href)) { return; }
+        if (form.querySelector('input[name="_csrf"]')) { return; }
+        var token = bizCsrfToken();
+        if (!token) { return; }
+        var input = document.createElement('input');
+        input.type = 'hidden'; input.name = '_csrf'; input.value = token;
+        form.appendChild(input);
+    }
+    // User-initiated submits (capture phase, before the form serializes)
+    document.addEventListener('submit', function (e) { bizCsrfInjectForm(e.target); }, true);
+    // Programmatic form.submit() does not fire the submit event — wrap it as well
+    try {
+        var nativeSubmit = HTMLFormElement.prototype.submit;
+        HTMLFormElement.prototype.submit = function () { bizCsrfInjectForm(this); return nativeSubmit.apply(this, arguments); };
+    } catch (e) { /* older browser: the submit-event listener still covers user submits */ }
+    // fetch() — add the header on same-origin, state-changing calls
+    if (window.fetch) {
+        var nativeFetch = window.fetch;
+        window.fetch = function (input, init) {
+            init = init || {};
+            var url = (typeof input === 'string') ? input : (input && input.url) || '';
+            var method = ((init.method || (typeof input === 'object' && input.method) || 'GET') + '').toUpperCase();
+            var token = bizCsrfToken();
+            if (token && bizCsrfSameOrigin(url) && method !== 'GET' && method !== 'HEAD') {
+                var headers = new Headers(init.headers || (typeof input === 'object' && input.headers) || {});
+                if (!headers.has('X-Bizuno-Csrf')) { headers.set('X-Bizuno-Csrf', token); }
+                init.headers = headers;
+            }
+            return nativeFetch.call(this, input, init);
+        };
+    }
+})();
+
 let stored = null;
 let storedVersion = null;
 if (sessionStorage.bizuno) {


### PR DESCRIPTION
### Problem

CSRF Layer 2 (`BIZUNO_CSRF_ENFORCE`) requires a token on every state-changing request. The `jqBiz.ajaxSetup` `beforeSend` hook in `common.js` attaches `X-Bizuno-Csrf` to all `jqBiz.ajax` calls automatically — but two common patterns bypass jQuery and so never get the token:

- **native `<form method="post">` submits** (including `target="_blank"` print/download forms)
- **raw `fetch()` calls**

For those, `validateCsrf()` finds no token and `goAuth()` redirects to the portal home without dispatching the route. `bizCsrfHiddenInput()` exists for hand-built forms, but it has to be remembered and added to every form, and there's no equivalent for `fetch()`.

### Change

A small same-origin shim right after the `ajaxSetup` block in `common.js` that attaches the same `bizCSRF` token to:

- native form submits (capture-phase `submit` listener)
- programmatic `form.submit()` (wraps `HTMLFormElement.prototype.submit`, which doesn't fire the submit event)
- `fetch()` (sets the `X-Bizuno-Csrf` header on same-origin, non-GET calls)

**Same-origin scoped**, so the token is never attached to a cross-origin request (no leakage). It reads the existing `bizCSRF` constant — nothing new is minted or exposed. Net effect: hand-built forms and `fetch()` callers are covered automatically, the same way `jqBiz.ajax` already is.

### Why it's safe

This changes only the **client-side token delivery** for legitimate same-origin requests; it does not touch the server-side enforcement (`validateCsrf()` / `goAuth()`), which is the actual security boundary. The token stays unreadable cross-origin (same-origin policy), and the shim never sends it off-origin. If the shim didn't run, affected forms would simply be rejected (fail-safe), not allowed through.

Found while bringing a set of custom modules with hand-built forms onto 7.4.5 — every non-ajax POST bounced to home until the token was attached. Happy to adjust placement/scope if you'd prefer it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
